### PR TITLE
Added portable sample implementation.

### DIFF
--- a/srfi/144.body.scm
+++ b/srfi/144.body.scm
@@ -1,0 +1,555 @@
+;;; Copyright (C) William D Clinger (2016).
+;;; 
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use,
+;;; copy, modify, merge, publish, distribute, sublicense, and/or
+;;; sell copies of the Software, and to permit persons to whom the
+;;; Software is furnished to do so, subject to the following
+;;; conditions:
+;;; 
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;; 
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;; OTHER DEALINGS IN THE SOFTWARE. 
+
+;;; References
+;;;
+;;; Milton Abramowitz and Irene A Stegun [editors].
+;;; Handbook of Mathematical Functions With Formulas, Graphs, and
+;;; Mathematical Tables.  United States Department of Commerce.
+;;; National Bureau of Standards Applied Mathematics Series, 55,
+;;; June 1964.  Fifth Printing, August 1966, with corrections.
+;;;
+;;; R W Hamming.  Numerical Methods for Scientists and Engineers.
+;;; McGraw-Hill, 1962.
+;;;
+;;; Donald E Knuth.  The Art of Computer Programming, Volume 2,
+;;; Seminumerical Algorithms, Second Edition.  Addison-Wesley, 1981.
+
+;;; I have deliberately avoided recent references, and have also
+;;; avoided looking at any code or pseudocode for these or similar
+;;; functions.
+
+;;; Quick-and-dirty implementation of a draft of SRFI 144 (flonums),
+;;; as specified at http://vrici.lojban.org/~cowan/temp/srfi-144.html
+;;; as of 4 June 2017.
+;;;
+;;; Why must the argument to make-fllog-base be an exact integer?
+;;;
+;;; FIXME: not as accurate as it should be
+;;; FIXME: not as fast as it should be
+;;; FIXME: assumes IEEE arithmetic or similar
+;;; FIXME: assumes all inexact reals are flonums
+;;; FIXME: assumes (scheme inexact)
+;;; FIXME: assumes (rnrs arithmetic flonums)
+
+;;; Mathematical Constants
+
+;;; For portability and ease of implementation, most are calculated.
+;;; Some numerical values are copied from Wikipedia or the references.
+;;; Inaccuracies will be revealed by testing and then repaired.
+
+(define fl-e (exp 1))
+(define fl-1/e (/ fl-e))
+
+(define fl-e-2 ; (* fl-e fl-e) is 1 bit low (Linux, IEEE double)
+  7.389056098930650227230427)
+
+(define fl-e-pi/4 (exp (/ (acos -1.0) 4.0)))
+(define fl-log2-e (log fl-e 2.0))
+
+(define fl-log10-e ; (log fl-e 10.0) is 1 bit low (Linux, IEEE double)
+  .4342944819032518276511289)
+
+(define fl-log-2 (log 2.0))
+(define fl-1/log-2 (/ fl-log-2))
+(define fl-log-3 (log 3.0))
+(define fl-log-pi (log (acos -1.0)))
+(define fl-log-10 (log 10.0))
+(define fl-1/log-10 ; (/ fl-log-10) is 1 bit low (Linux, IEEE double)
+  fl-log10-e)
+
+(define fl-pi (acos -1.0))
+(define fl-1/pi (/ fl-pi))
+(define fl-2pi (* 2.0 fl-pi))
+(define fl-pi/2 (/ fl-pi 2.0))
+(define fl-pi/4 (/ fl-pi 4.0))
+(define fl-2/sqrt-pi (/ 2.0 (sqrt fl-pi)))
+(define fl-pi-squared (* fl-pi fl-pi))
+(define fl-degree (/ fl-pi 180.0))
+(define fl-2/pi (/ 2.0 fl-pi))
+;(define fl-2/sqrt-pi fl-2/sqrt-pi)   ; specified twice in draft of SRFI 144
+(define fl-sqrt-2 (sqrt 2.0))
+(define fl-sqrt-3 (sqrt 3.0))
+(define fl-sqrt-5 (sqrt 5.0))
+(define fl-sqrt-10 (sqrt 10.0))
+
+(define fl-1/sqrt-2 ; (/ fl-sqrt-2) is 1 bit low (Linux, IEEE double)
+  (/ fl-sqrt-2 2.0))
+
+(define fl-cbrt-2 (expt 2.0 (inexact 1/3)))
+(define fl-cbrt-3 (expt 3.0 (inexact 1/3)))
+(define fl-4thrt-2 (expt 2.0 .25))
+(define fl-phi (/ (+ 1.0 (sqrt 5.0)) 2.0))
+(define fl-log-phi (log fl-phi))
+
+(define fl-1/log-phi ; fl-log-phi) ; is 1 bit low (Linux, IEEE double)
+  2.0780869212350275376013226061177957677422)
+
+(define fl-euler 0.57721566490153286060651209008240243104215933593992)
+(define fl-e-euler (exp fl-euler))
+(define fl-sin-1 (sin 1.0))
+(define fl-cos-1 (cos 1.0))
+
+(define fl-gamma-1/2 ; (sqrt fl-pi) is 1 bit low (Linux, IEEE double)
+  1.7724538509055160272981674833411451827975)
+
+(define fl-gamma-1/3 2.6789385347077476336556929409746776441287)
+(define fl-gamma-2/3 1.3541179394264004169452880281545137855193)
+
+;; Implementation Constants
+
+(define fl-greatest
+  (let loop ((x (- (expt 2.0 precision-bits) 1.0)))
+    (if (finite? (* 2.0 x))
+        (loop (* 2.0 x))
+        x)))
+
+(define fl-least
+  (let loop ((x 1.0))
+    (if (> (/ x 2.0) 0.0)
+        (loop (/ x 2.0))
+        x)))
+
+(define fl-epsilon
+  (let loop ((eps 1.0))
+    (if (= 1.0 (+ 1.0 eps))
+        (* 2.0 eps)
+        (loop (/ eps 2.0)))))
+
+(define fl-integer-exponent-zero                ; arbitrary
+  (exact (- (log fl-least 2.0) 1.0)))
+
+(define fl-integer-exponent-nan                 ; arbitrary
+  (- fl-integer-exponent-zero 1))
+
+;;; Constructors
+
+(define (flonum x)
+  (if (real? x)
+      (inexact x)
+      (error "bad argument passed to flonum" x)))
+
+(define fladjacent
+  (flop2 'fladjacent
+         (lambda (x y)
+           (define (loop y)
+             (let ((y2 (fl/ (fl+ x y) 2.0)))
+               (cond ((fl=? x y2)
+                      y)
+                     ((fl=? y y2)
+                      y)
+                     (else
+                      (loop y2)))))
+           (cond ((flinfinite? x)
+                  (cond ((fl<? x y) (fl- fl-greatest))
+                        ((fl>? x y) fl-greatest)
+                        (else x)))
+                 ((fl=? x y)
+                  x)
+                 ((flzero? x)
+                  (if (flpositive? y)
+                      fl-least
+                      (fl- fl-least)))
+                 ((fl<? x y)
+                  (loop (flmin y
+                               fl-greatest
+                               (flmax (* 2.0 x)
+                                      (* 0.5 x)))))
+                 ((fl>? x y)
+                  (loop (flmax y
+                               (fl- fl-greatest)
+                               (flmin (* 2.0 x)
+                                      (* 0.5 x)))))
+                 (else    ; x or y is a NaN
+                  x)))))
+
+(define flcopysign
+  (flop2 'flcopysign
+         (lambda (x y)
+           (if (= (flsign-bit x) (flsign-bit y))
+               x
+               (fl- x)))))
+
+(define (make-flonum x n)
+  (let ((y (expt 2.0 n)))
+    (cond ((or (not (flonum? x))
+               (not (exact-integer? n)))
+           (error "bad arguments to make-flonum" x n))
+          ((finite? y)
+           (* x y))
+          (else
+           (inexact (* (exact x) (expt 2 n)))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Accessors
+
+(define (flinteger-fraction x)
+  (check-flonum! 'flinteger-fraction x)
+  (let* ((result1 (fltruncate x))
+         (result2 (fl- x result1)))
+    (values result1 result2)))
+
+(define (flexponent x)
+  (fllog2 (flabs x)))
+
+(define (flinteger-exponent x)
+  (exact (fltruncate (flexponent x))))
+
+(define (flnormalized-fraction-exponent x)
+  (define (return result1 result2)
+    (cond ((fl<? result1 0.5)
+           (values (fl* 2.0 result1) (- result2 1)))
+          ((fl>=? result1 1.0)
+           (values (fl* 0.5 result1) (+ result2 1)))
+          (else
+           (values result1 result2))))
+  (check-flonum! 'flnormalized-fraction-exponent x)
+  (cond ((flnan? x)    ; unspecified for NaN
+         (values x 0))
+        ((fl<? x 0.0)
+         (call-with-values
+          (lambda () (flnormalized-fraction-exponent (fl- x)))
+          (lambda (y n)
+            (values (fl- y) n))))
+        ((fl=? x 0.0)    ; unspecified for 0.0
+         (values 0.0 0))
+        ((flinfinite? x)
+         (values 0.5 (+ 3 (exact (round (flexponent fl-greatest))))))
+        ((flnormalized? x)
+         (let* ((result2 (exact (flround (flexponent x))))
+                (two^result2 (inexact (expt 2.0 result2))))
+           (if (flinfinite? two^result2)
+               (call-with-values
+                (lambda () (flnormalized-fraction-exponent (fl/ x 4.0)))
+                (lambda (y n)
+                  (values y (+ n 2))))
+               (return (fl/ x two^result2) result2))))
+        (else
+         (let* ((k (+ 2 precision-bits))
+                (two^k (expt 2 k)))
+           (call-with-values
+            (lambda ()
+              (flnormalized-fraction-exponent (fl* x (inexact two^k))))
+            (lambda (y n)
+              (return y (- n k))))))))
+
+(define (flsign-bit x)
+  (check-flonum! 'flsign-bit x)
+  (cond ((fl<? x 0.0)
+         1)
+        ((eqv? x -0.0)
+         1)
+        (else
+         0)))
+
+
+;;; Predicates
+
+;(define flonum? R6RS)               ; defined by (rnrs arithmetic flonums)
+;(define fl=? R6RS)                  ; defined by (rnrs arithmetic flonums)
+;(define fl<? R6RS)                  ; defined by (rnrs arithmetic flonums)
+;(define fl>? R6RS)                  ; defined by (rnrs arithmetic flonums)
+;(define fl<=? R6RS)                 ; defined by (rnrs arithmetic flonums)
+;(define fl>=? R6RS)                 ; defined by (rnrs arithmetic flonums)
+
+(define (flunordered? x y)
+  (or (flnan? x) (flnan? y)))
+
+;;; incompatible with (rnrs arithmetic flonums) in zero-argument case
+
+(define flmax
+  (let ((flmax2 (flop2 'flmax max)))
+    (lambda args
+      (cond ((null? args)
+             -inf.0)
+            ((null? (cdr args))
+             (car args))
+            ((null? (cddr args))
+             (flmax2 (car args) (cadr args)))
+            (else
+             (flmax2 (flmax2 (car args) (cadr args))
+                     (apply flmax (cddr args))))))))
+
+;;; incompatible with (rnrs arithmetic flonums) in zero-argument case
+
+(define flmin
+  (let ((flmin2 (flop2 'flmin min)))
+    (lambda args
+      (cond ((null? args)
+             +inf.0)                 ; spec says fl-least, but that's wrong
+            ((null? (cdr args))
+             (car args))
+            ((null? (cddr args))
+             (flmin2 (car args) (cadr args)))
+            (else
+             (flmin2 (flmin2 (car args) (cadr args))
+                     (apply flmin (cddr args))))))))
+
+;(define flinteger? R6RS)            ; defined by (rnrs arithmetic flonums)
+;(define flzero? R6RS)               ; defined by (rnrs arithmetic flonums)
+;(define flpositive? R6RS)           ; defined by (rnrs arithmetic flonums)
+;(define flnegative? R6RS)           ; defined by (rnrs arithmetic flonums)
+;(define flodd? R6RS)                ; defined by (rnrs arithmetic flonums)
+;(define fleven? R6RS)               ; defined by (rnrs arithmetic flonums)
+;(define flfinite? R6RS)             ; defined by (rnrs arithmetic flonums)
+;(define flinfinite? R6RS)           ; defined by (rnrs arithmetic flonums)
+;(define flnan? R6RS)                ; defined by (rnrs arithmetic flonums)
+
+(define flnormalized?
+  (lambda (x)
+    (check-flonum! 'flnormalized? x)
+    (let ((x (flabs x)))
+      (and (flfinite? x)
+           (fl<? (fl/ fl-greatest) x)))))
+
+(define fldenormalized?
+  (lambda (x)
+    (check-flonum! 'fldenormalized? x)
+    (let ((x (flabs x)))
+      (and (flfinite? x)
+           (fl<? 0.0 x)
+           (fl<=? x (fl/ fl-greatest))))))
+
+;;; Arithmetic
+
+;(define fl+ R6RS)                   ; defined by (rnrs arithmetic flonums)
+;(define fl* R6RS)                   ; defined by (rnrs arithmetic flonums)
+
+;;; Spec says "as if to infinite precision and rounded only once".
+
+(define fl+*
+  (flop3 'fl+*
+         (lambda (x y z)
+           (cond (c-functions-are-available
+                  (fma x y z))
+                 ((and (flfinite? x) (flfinite? y))
+                  (if (flfinite? z)
+                      (let ((x (exact x))
+                            (y (exact y))
+                            (z (exact z)))
+                        (flonum (+ (* x y) z)))
+                      z))
+                 (else
+                  (fl+ (fl* x y) z))))))
+
+;(define fl- R6RS)                   ; defined by (rnrs arithmetic flonums)
+;(define fl/ R6RS)                   ; defined by (rnrs arithmetic flonums)
+;(define flabs R6RS)                 ; defined by (rnrs arithmetic flonums)
+
+(define (flabsdiff x y)
+  (flabs (fl- x y)))
+
+(define (flposdiff x y)
+  (let ((diff (fl- x y)))
+    (if (flnegative? diff)
+        0.0
+        diff)))
+
+(define (flsgn x)
+  (flcopysign 1.0 x))
+
+;;; (flnumerator +nan.0) and (fldenominator +nan.0) must be NaNs, which
+;;; is not required by the R6RS specification of (rnrs arithmetic flonums).
+
+(define flnumerator
+  (flop1 'flnumerator
+         (lambda (x)
+           (if (flnan? x)
+               x
+               (r6rs:flnumerator x)))))
+
+(define fldenominator
+  (flop1 'fldenominator
+         (lambda (x)
+           (if (flnan? x)
+               x
+               (r6rs:fldenominator x)))))
+
+;(define flfloor R6RS)               ; defined by (rnrs arithmetic flonums)
+;(define flceiling R6RS)             ; defined by (rnrs arithmetic flonums)
+;(define flround R6RS)               ; defined by (rnrs arithmetic flonums)
+;(define fltruncate R6RS)            ; defined by (rnrs arithmetic flonums)
+
+;;; Exponents and logarithms
+
+;(define flexp R6RS)                 ; defined by (rnrs arithmetic flonums)
+
+(define flexp2 (flop1 'flexp2 (lambda (x) (flexpt 2.0 x))))
+
+;;; e^x = \sum_n (z^n / (n!))
+;;;
+;;; FIXME: the number of terms and the constant 0.5 seem reasonable
+;;; for IEEE double precision, but the number of terms might need
+;;; to be increased for higher precisions.
+
+(define flexp-1
+  (flop1 'flexp-1
+         (let ((coefs (cons 0.0
+                            (map fl/
+                                 (map factorial
+                                      '(1.0 2.0 3.0 4.0 5.0
+                                        6.0 7.0 8.0 9.0 10.0
+                                        11.0 12.0 13.0 14.0 15.0))))))
+           (lambda (x)
+             (cond ((fl<? (flabs x) 0.5)    ; FIXME
+                    (polynomial-at x coefs))
+                   (else
+                    (fl- (flexp x) 1.0)))))))
+
+(define flsquare (flop1 'flsquare (lambda (x) (fl* x x))))
+
+;(define flsqrt R6RS)                ; defined by (rnrs arithmetic flonums)
+
+(define flcbrt
+  (flop1 'flcbrt
+         (lambda (x)
+           (cond ((flnegative? x)
+                  (fl- (flcbrt (fl- x))))
+                 (else
+                  (flexpt x (fl/ 3.0)))))))
+
+(define flhypot
+  (flop2 'flhypot
+         (lambda (x y)
+           (cond ((flzero? x) (flabs y))
+                 ((flzero? y) (flabs x))
+                 ((or (flinfinite? x) (flinfinite? y)) +inf.0)
+                 ((flnan? x) x)
+                 ((flnan? y) y)
+                 ((fl>? y x) (flhypot y x))
+                 (else
+                  (let* ((y/x (fl/ y x))
+                         (root (flsqrt (fl+ 1.0 (fl* y/x y/x)))))
+                    (fl* (flabs x) root)))))))
+
+;(define flexpt R6RS)                ; defined by (rnrs arithmetic flonums)
+;(define fllog R6RS)                 ; defined by (rnrs arithmetic flonums)
+
+;;; Returns log(x+1), as in C99 log1p.
+;;;
+;;; log (x + 1) = \sum_{n=1}^\infty - (-1)^n x^n/n
+
+(define fllog1+
+  (flop1 'fllog1+
+         (let ((coefs (cons 0.0
+                            (map fl/
+                                 '(1.0 -2.0 3.0 -4.0 5.0
+                                   -6.0 7.0 -8.0 9.0 -10.0)))))
+           (lambda (x)
+             (cond ((fl<? (flabs x) 0.5)    ; FIXME
+                    (polynomial-at x coefs))
+                   (else
+                    (fllog (fl+ 1.0 x))))))))
+           
+
+(define fllog2 (flop1 'fllog2 (lambda (x) (log x 2.0))))
+
+(define fllog10 (flop1 'fllog10 (lambda (x) (log x 10.0))))
+
+(define (make-fllog-base k)
+  (if (and (exact-integer? k) (> k 1))
+      (flop1 'procedure-created-by-make-fllog-base
+             (let ((base (inexact k)))
+               (lambda (x) (log x base))))
+      (error "bad argument passed to make-fllog-base" k)))
+
+;;; Trigonometric functions
+
+;(define flsin R6RS)                 ; defined by (rnrs arithmetic flonums)
+;(define flcos R6RS)                 ; defined by (rnrs arithmetic flonums)
+;(define fltan R6RS)                 ; defined by (rnrs arithmetic flonums)
+;(define flasin R6RS)                ; defined by (rnrs arithmetic flonums)
+;(define flacos R6RS)                ; defined by (rnrs arithmetic flonums)
+;(define flatan R6RS)                ; defined by (rnrs arithmetic flonums)
+
+(define flsinh
+  (flop1 'flsinh
+         (lambda (x)
+           (cond ((not (flfinite? x)) x)
+                 (else
+                  (fl/ (fl- (flexp x) (flexp (fl- x))) 2.0))))))
+
+(define flcosh
+  (flop1 'flcosh
+         (lambda (x)
+           (cond ((not (flfinite? x)) (flabs x))
+                 (else
+                  (fl/ (fl+ (flexp x) (flexp (fl- x))) 2.0))))))
+
+(define fltanh
+  (flop1 'fltanh
+         (lambda (x)
+           (cond ((flinfinite? x) (flcopysign 1.0 x))
+                 ((flnan? x) x)
+                 (else
+                  (fl/ (flsinh x) (flcosh x)))))))
+
+;;; inverse hyperbolic functions
+
+(define flasinh
+  (flop1 'flasinh
+         (lambda (x)
+           (cond ((flzero? x) x)
+                 ((not (flfinite? x)) x)
+                 (else
+                  (fllog (fl+ x (flsqrt (fl+ (fl* x x) 1.0)))))))))
+
+(define flacosh
+  (flop1 'flacosh
+         (lambda (x)
+           (fllog (fl+ x (flsqrt (fl- (fl* x x) 1.0)))))))
+
+(define flatanh
+  (flop1 'flatanh
+         (lambda (x)
+           (cond ((flzero? x) x)
+                 (else
+                  (fl* 0.5 (fllog (fl/ (fl+ 1.0 x) (fl- 1.0 x)))))))))
+
+;;; Integer division
+
+(define flquotient
+  (flop2 'flquotient
+         (lambda (x y)
+           (fltruncate (fl/ x y)))))
+
+;;; FIXME: should probably implement the following part of the C spec:
+;;; "If the returned value is 0, it will have the same sign as x."
+
+(define flremainder
+  (flop2 'flremainder
+         (lambda (x y)
+           (fl- x (fl* y (flquotient x y))))))
+
+(define (flremquo x y)
+  (check-flonum! 'flremquo x)
+  (check-flonum! 'flremquo y)
+  (let* ((quo (flround (fl/ x y)))
+         (rem (fl- x (fl* y quo))))
+    (values rem
+            (exact quo))))
+
+;; Special functions are defined in 144.special.scm
+
+; eof

--- a/srfi/144.body0.scm
+++ b/srfi/144.body0.scm
@@ -1,0 +1,118 @@
+;;; Private but portable code.
+
+(define FIXME 'FIXME)
+
+(define precision-bits    ; IEEE double has 53 bits of precision
+  (let loop ((bits 0)
+             (x 1.0))
+    (if (= x (+ x 1.0))
+        bits
+        (loop (+ bits 1)
+              (* 2.0 x)))))
+
+(define (check-flonum! name x)
+  (if (not (flonum? x))
+      (error (string-append "non-flonum argument passed to "
+                            (symbol->string name))
+             x)))
+
+;;; Given a symbol naming a flonum procedure and a generic operation,
+;;; returns a flonum procedure that restricts the generic operation
+;;; to flonum arguments and result.
+
+(define (flop1 name op)
+  (lambda (x)
+    (check-flonum! name x)
+    (let ((result (op x)))
+      (if (not (flonum? result))
+          (error (string-append "non-flonum result from "
+                                (symbol->string name))
+                 result))
+      result)))
+
+(define (flop2 name op)
+  (lambda (x y)
+    (check-flonum! name x)
+    (check-flonum! name y)
+    (let ((result (op x y)))
+      (if (not (flonum? result))
+          (error (string-append "non-flonum result from "
+                                (symbol->string name))
+                 result))
+      result)))
+
+(define (flop3 name op)
+  (lambda (x y z)
+    (check-flonum! name x)
+    (check-flonum! name y)
+    (check-flonum! name z)
+    (let ((result (op x y z)))
+      (if (not (flonum? result))
+          (error (string-append "non-flonum result from "
+                                (symbol->string name))
+                 result))
+      result)))
+
+;;; Given a flonum x and a list of flonum coefficients for a polynomial,
+;;; in order of increasing degree, returns the value of the polynomial at x.
+
+(define (polynomial-at x coefs)
+  (if (null? coefs)
+      0.0
+#;    (fma x (polynomial-at x (cdr coefs)) (car coefs)) ; doesn't help
+      (fl+ (car coefs)
+           (fl* x (polynomial-at x (cdr coefs))))))
+
+;;; This uses Simpson's rule.
+
+(define (definite-integral lower upper f . rest)
+  (let* ((range (fl- upper lower))
+         (kmax (if (or (null? rest)
+                       (not (and (exact-integer? (car rest))
+                                 (even? (car rest))
+                                 (positive? (car rest)))))
+                   1024 ; FIXME: must be even, should be power of 2
+                   (car rest)))
+         (n2 (inexact kmax))
+         (h (fl/ range n2)))
+    (define (loop k n sum)    ; n = (inexact k)
+      (cond ((= k 0)
+             (loop 1 1.0 (f lower)))
+            ((= k kmax)
+             (fl+ sum (f upper)))
+            (else
+             (let ((fn (f (+ lower (fl/ (fl* n range) n2)))))
+               (loop (+ k 1)
+                     (fl+ n 1.0)
+                     (fl+ sum (fl* (if (even? k) 2.0 4.0) fn)))))))
+    (fl/ (fl* h (loop 0 0.0 0.0))
+         3.0)))
+
+;;; Given x between x0 and x1, interpolates between f0 and f1.
+;;; Can also extrapolate.
+
+(define (interpolate x x0 x1 f0 f1)
+  (let ((delta (fl- x1 x0)))
+    (fl+ (fl* (fl/ (fl- x1 x) delta) f0)
+         (fl* (fl/ (fl- x x0) delta) f1))))
+
+(define (iota n)
+  (do ((n (- n 1) (- n 1))
+       (x '() (cons n x)))
+      ((< n 0) x)))
+
+;;; Given a exact non-negative integer, returns its factorial.
+
+(define (fact x)
+  (if (zero? x)
+      1
+      (* x (fact (- x 1)))))
+
+;;; Given a non-negative integral flonum x, returns its factorial.
+
+(define (factorial x)
+  (if (flzero? x)
+      1.0
+      (fl* x (factorial (fl- x 1.0)))))
+
+; eof

--- a/srfi/144.ffi.scm
+++ b/srfi/144.ffi.scm
@@ -1,0 +1,69 @@
+;;; For most of the procedures specified by SRFI 144, it's faster
+;;; and just as accurate to use the portable definition instead
+;;; of going through Larceny's FFI.
+;;;
+;;; Only three of the SRFI 144 procedures are substantially more
+;;; accurate or faster when implemented using Larceny's FFI:
+;;;
+;;;     fl+*
+;;;     flfirst-bessel
+;;;     flsecond-bessel
+
+(define ignored-result-of-loading-ffi (require 'std-ffi))
+
+(define nextafter (foreign-procedure "nextafter" '(double double) 'double))
+(define copysign  (foreign-procedure "copysign"  '(double double) 'double))
+(define ldexp     (foreign-procedure "ldexp"     '(double int)    'double))
+(define modf      (foreign-procedure "modf"      '(double int)    'double))
+(define logb      (foreign-procedure "logb"      '(double)        'double))
+(define ilogb     (foreign-procedure "ilogb"     '(double)        'int))
+(define frexp     (foreign-procedure "frexp"     '(double boxed)  'double))
+;(define signbit     'MACRO)
+
+;(define isfinite    'MACRO)
+;(define isinf       'MACRO)
+;(define isnan       'MACRO)
+;(define isnormal    'MACRO)    ; fpclassify is also a macro
+;(define issubnormal 'MACRO)    ; fpclassify is also a macro
+
+(define fma      (foreign-procedure "fma" '(double double double) 'double))
+(define fabs      (foreign-procedure "fabs"      '(double)        'double))
+(define fdim      (foreign-procedure "fdim"      '(double double) 'double))
+(define c:floor   (foreign-procedure "floor"     '(double)        'double))
+(define ceil      (foreign-procedure "ceil"      '(double)        'double))
+(define c:round   (foreign-procedure "round"     '(double)        'double))
+(define trunc     (foreign-procedure "trunc"     '(double)        'double))
+
+(define c:exp     (foreign-procedure "exp"       '(double)        'double))
+(define exp2      (foreign-procedure "exp2"      '(double)        'double))
+(define expm1     (foreign-procedure "expm1"     '(double)        'double))
+(define c:sqrt    (foreign-procedure "sqrt"      '(double)        'double))
+(define cbrt      (foreign-procedure "cbrt"      '(double)        'double))
+(define hypot     (foreign-procedure "hypot"     '(double double) 'double))
+(define pow       (foreign-procedure "pow"       '(double double) 'double))
+(define c:log     (foreign-procedure "log"       '(double)        'double))
+(define log1p     (foreign-procedure "log1p"     '(double)        'double))
+(define log2      (foreign-procedure "log2"      '(double)        'double))
+(define log10     (foreign-procedure "log10"     '(double)        'double))
+
+(define c:sin     (foreign-procedure "sin"       '(double)        'double))
+(define c:cos     (foreign-procedure "cos"       '(double)        'double))
+(define c:tan     (foreign-procedure "tan"       '(double)        'double))
+(define c:asin    (foreign-procedure "asin"      '(double)        'double))
+(define c:acos    (foreign-procedure "acos"      '(double)        'double))
+(define c:atan    (foreign-procedure "atan"      '(double)        'double))
+(define atan2     (foreign-procedure "atan2"     '(double double) 'double))
+
+(define sinh      (foreign-procedure "sinh"      '(double)        'double))
+(define cosh      (foreign-procedure "cosh"      '(double)        'double))
+(define tanh      (foreign-procedure "tanh"      '(double)        'double))
+(define asinh     (foreign-procedure "asinh"     '(double)        'double))
+(define acosh     (foreign-procedure "acosh"     '(double)        'double))
+(define atanh     (foreign-procedure "atanh"     '(double)        'double))
+
+(define tgamma    (foreign-procedure "tgamma"    '(double)        'double))
+(define lgamma    (foreign-procedure "lgamma"    '(double)        'double))
+(define jn        (foreign-procedure "jn"        '(int double)    'double))
+(define yn        (foreign-procedure "yn"        '(int double)    'double))
+(define erf       (foreign-procedure "erf"       '(double)        'double))
+(define erfc      (foreign-procedure "erfc"      '(double)        'double))

--- a/srfi/144.r6rs.scm
+++ b/srfi/144.r6rs.scm
@@ -1,0 +1,107 @@
+;;; If (rnrs arithmetic flonums) is unavailable, these definitions are used.
+
+;;; Private.
+
+(define (flop0-or-more name op)
+  (lambda args
+    (for-each (lambda (x) (check-flonum! name x)) args)
+    (let ((result (apply op args)))
+      (if (not (flonum? result))
+          (error (string-append "non-flonum result from "
+                              (symbol->string name))
+                              result))
+      result)))
+
+(define (flop1-or-more name op)
+  (lambda (x . args)
+    (for-each (lambda (x) (check-flonum! name x)) (cons x args))
+    (let ((result (apply op x args)))
+      (if (not (flonum? result))
+          (error (string-append "non-flonum result from "
+                              (symbol->string name))
+                              result))
+      result)))
+
+(define (flop2-or-more name op)
+  (lambda (x y . args)
+    (for-each (lambda (x) (check-flonum! name x)) (cons x (cons y args)))
+    (let ((result (apply op x y args)))
+      (if (not (flonum? result))
+          (error (string-append "non-flonum result from "
+                              (symbol->string name))
+                              result))
+      result)))
+
+(define (flop2-or-more name op)
+  (lambda (x y . args)
+    (for-each (lambda (x) (check-flonum! name x)) (cons x (cons y args)))
+    (let ((result (apply op x y args)))
+      (if (not (flonum? result))
+          (error (string-append "non-flonum result from "
+                              (symbol->string name))
+                              result))
+      result)))
+
+(define (flpred1 name op)
+  (lambda (x)
+    (check-flonum! name x)
+    (op x)))
+
+(define (flpred2-or-more name op)
+  (lambda (x y . args)
+    (for-each (lambda (x) (check-flonum! name x)) (cons x (cons y args)))
+    (apply op x y args)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Exported.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (flonum? x)
+  (and (number? x)
+       (real? x)
+       (inexact? x)
+       (exact? (imag-part x))))
+
+(define fl=?  (flpred2-or-more 'fl=? =))
+(define fl<?  (flpred2-or-more 'fl<? <=))
+(define fl>?  (flpred2-or-more 'fl>? >))
+(define fl<=? (flpred2-or-more 'fl<=? <=))
+(define fl>=? (flpred2-or-more 'fl>=? >=))
+
+(define flinteger?  (flpred1 'flinteger?  integer?))
+(define flzero?     (flpred1 'flzero?     zero?))
+(define flpositive? (flpred1 'flpositive? positive?))
+(define flnegative? (flpred1 'flnegative? negative?))
+(define flodd?      (flpred1 'flodd?      odd?))
+(define fleven?     (flpred1 'fleven?     even?))
+(define flfinite?   (flpred1 'flfinite?   finite?))
+(define flinfinite? (flpred1 'flinfinite? infinite?))
+(define flnan?      (flpred1 'flnan?      nan?))
+
+(define fl+        (flop0-or-more 'fl+ +))
+(define fl*        (flop0-or-more 'fl* *))
+(define fl-        (flop1-or-more 'fl- -))
+(define fl/        (flop1-or-more 'fl/ /))
+
+(define flabs      (flop1 'flabs      abs))
+
+(define flfloor    (flop1 'flfloor    floor))
+(define flceiling  (flop1 'flceiling  ceiling))
+(define flround    (flop1 'flround    round))
+(define fltruncate (flop1 'fltruncate truncate))
+
+(define r6rs:flnumerator   numerator)
+(define r6rs:fldenominator denominator)
+
+(define flexp      (flop1 'flexp  exp))
+(define flsqrt     (flop1 'flsqrt sqrt))
+(define flexpt     (flop1 'flexpt expt))
+(define fllog      (flop1 'fllog  log))
+(define flsin      (flop1 'flsin  sin))
+(define flcos      (flop1 'flcos  cos))
+(define fltan      (flop1 'fltan tan))
+(define flasin     (flop1 'flasin asin))
+(define flacos     (flop1 'flacos acos))
+(define flatan     (flop1-or-more 'flatan atan)) ; FIXME 1 or 2 arguments

--- a/srfi/144.sld
+++ b/srfi/144.sld
@@ -1,0 +1,239 @@
+;;; SRFI 144 (flonums, in draft status)
+;;;
+;;; $Id$
+;;;
+;;; Copyright (C) William D Clinger (2016).
+;;; 
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use,
+;;; copy, modify, merge, publish, distribute, sublicense, and/or
+;;; sell copies of the Software, and to permit persons to whom the
+;;; Software is furnished to do so, subject to the following
+;;; conditions:
+;;; 
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;; 
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;; OTHER DEALINGS IN THE SOFTWARE. 
+
+
+(define-library (srfi 144)
+
+  (export
+
+   ;; Mathematical Constants
+
+   fl-e
+   fl-1/e
+   fl-e-2
+   fl-e-pi/4
+   fl-log2-e
+   fl-log10-e
+   fl-log-2
+   fl-1/log-2
+   fl-log-3
+   fl-log-pi
+   fl-log-10
+   fl-1/log-10
+   fl-pi
+   fl-1/pi
+   fl-2pi
+   fl-pi/2
+   fl-pi/4
+   fl-2/sqrt-pi
+   fl-pi-squared
+   fl-degree
+   fl-2/pi
+;  fl-2/sqrt-pi    ; FIXME: duplicate
+   fl-sqrt-2
+   fl-sqrt-3
+   fl-sqrt-5
+   fl-sqrt-10
+   fl-1/sqrt-2
+   fl-cbrt-2
+   fl-cbrt-3
+   fl-4thrt-2
+   fl-phi
+   fl-log-phi
+   fl-1/log-phi
+   fl-euler
+   fl-e-euler
+   fl-sin-1
+   fl-cos-1
+   fl-gamma-1/2
+   fl-gamma-1/3
+   fl-gamma-2/3
+
+   ;; Implementation Constants
+
+   fl-greatest
+   fl-least
+   fl-epsilon
+   fl-fast-fl+*
+   fl-integer-exponent-zero
+   fl-integer-exponent-nan
+
+   ;; Constructors
+
+   flonum
+   fladjacent
+   flcopysign
+   make-flonum
+
+   ;; Accessors
+
+   flinteger-fraction
+   flexponent
+   flinteger-exponent
+   flnormalized-fraction-exponent
+   flsign-bit
+
+   ;; Predicates
+
+   flonum?
+   fl=?
+   fl<?
+   fl>?
+   fl<=?
+   fl>=?
+   flunordered?
+   flmax
+   flmin
+   flinteger?
+   flzero?
+   flpositive?
+   flnegative?
+   flodd?
+   fleven?
+   flfinite?
+   flinfinite?
+   flnan?
+   flnormalized?
+   fldenormalized?
+
+   ;; Arithmetic
+
+   fl+
+   fl*
+   fl+*
+   fl-
+   fl/
+   flabs
+   flabsdiff
+   flposdiff
+   flsgn
+   flnumerator
+   fldenominator
+   flfloor
+   flceiling
+   flround
+   fltruncate
+
+   ;; Exponents and logarithsm
+
+   flexp
+   flexp2
+   flexp-1
+   flsquare
+   flsqrt
+   flcbrt
+   flhypot
+   flexpt
+   fllog
+   fllog1+
+   fllog2
+   fllog10
+   make-fllog-base
+
+   ;; Trigonometric functions
+
+   flsin
+   flcos
+   fltan
+   flasin
+   flacos
+   flatan
+   flsinh
+   flcosh
+   fltanh
+   flasinh
+   flacosh
+   flatanh
+
+   ;; Integer division
+
+   flquotient
+   flremainder
+   flremquo
+
+   ;; Special functions
+
+   flgamma
+   flloggamma
+   flfirst-bessel
+   flsecond-bessel
+   flerf
+   flerfc
+   )
+
+  (import (scheme base)
+          (scheme inexact))
+
+  ;; Use (rnrs arithmetic flonums) if that library is available.
+
+  (cond-expand
+   ((library (rnrs arithmetic flonums))
+    (import (except (rnrs arithmetic flonums)
+                    flmax flmin flnumerator fldenominator)
+            (prefix (only (rnrs arithmetic flonums)
+                          flnumerator fldenominator)
+                    r6rs:)))
+   (else
+    (import (scheme complex))))
+
+  ;; Use an FFI if one is available.
+
+  (cond-expand
+   ((and larceny i386 unix (or gnu-linux darwin))
+    (import (rename (primitives r5rs:require)
+                    (r5rs:require require))
+            (primitives foreign-procedure)))
+   (else))
+
+  (include "144.body0.scm")
+
+  ;; If (rnrs arithmetic flonums) is not available, fake it.
+
+  (cond-expand
+   ((not (library (rnrs arithmetic flonums)))
+    (include "144.r6rs.scm"))
+   (else))
+
+  (include "144.body.scm")
+  (include "144.special.scm")
+
+  ;; If the C library is available, use it.
+
+  (cond-expand
+   ((and larceny i386 unix (or gnu-linux darwin))
+    (begin (define c-functions-are-available #t)
+           (define fl-fast-fl+* #f))
+    (include "144.ffi.scm"))
+   (else
+    (begin (define c-functions-are-available #f)
+           (define fl-fast-fl+* #f)
+           (define (fma x y z) (error "fma not defined"))
+           (define (jn n x) (error "jn not defined"))
+           (define (yn n x) (error "yn not defined")))))
+  )
+
+;;; eof

--- a/srfi/144.special.scm
+++ b/srfi/144.special.scm
@@ -1,0 +1,778 @@
+;;; Copyright (C) William D Clinger (2016).
+;;; 
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use,
+;;; copy, modify, merge, publish, distribute, sublicense, and/or
+;;; sell copies of the Software, and to permit persons to whom the
+;;; Software is furnished to do so, subject to the following
+;;; conditions:
+;;; 
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;; 
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;; OTHER DEALINGS IN THE SOFTWARE. 
+
+;;; References
+;;;
+;;; Milton Abramowitz and Irene A Stegun [editors].
+;;; Handbook of Mathematical Functions With Formulas, Graphs, and
+;;; Mathematical Tables.  United States Department of Commerce.
+;;; National Bureau of Standards Applied Mathematics Series, 55,
+;;; June 1964.  Fifth Printing, August 1966, with corrections.
+;;;
+;;; R W Hamming.  Numerical Methods for Scientists and Engineers.
+;;; McGraw-Hill, 1962.
+;;;
+;;; Donald E Knuth.  The Art of Computer Programming, Volume 2,
+;;; Seminumerical Algorithms, Second Edition.  Addison-Wesley, 1981.
+
+;;; I have deliberately avoided recent references, and have also
+;;; avoided looking at any code or pseudocode for these or similar
+;;; functions.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Gamma function
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Abramowitz and Stegun 6.1.5 ::  z! = Gamma(z+1)
+;;; Abramowitz and Stegun 6.1.15 :  Gamma(z+1) = z Gamma(z)
+;;;
+;;; Gamma(x+2) = (x+1) Gamma(x+1) = (x+1) x Gamma(x)
+;;; Gamma(x) = Gamma(x+2) / (x (x + 1))
+;;;
+;;; Those equations reduce the computation of Gamma(x) to the range
+;;;     1.0 <= x <= 2.0
+;;;
+;;; The following definition is more accurate than C99 tgamma
+;;; with gcc, Linux, and double precision.  The alarmingly large
+;;; absolute errors near 16.0 and -2.0e-16 are small relative
+;;; errors.  At x=16.0, tgamma returns a non-integer result,
+;;; but flgamma returns the correct integer result.
+
+(define (flgamma x)
+  (check-flonum! 'flgamma x)
+  (cond ((fl>=? x flgamma:upper-cutoff)
+         +inf.0)
+        ((fl<=? x flgamma:lower-cutoff)
+         (cond ((= x -inf.0)
+                +nan.0)
+               ((flinteger? x)    ; pole error
+                +nan.0)
+               ((flodd? (fltruncate x)) 0.0)
+               (else -0.0)))
+        (else (Gamma x))))
+
+(define (Gamma x)
+  (cond ((fl>? x 2.0)
+         (let ((x (fl- x 2.0)))
+           (fl* x (fl+ x 1.0) (Gamma x))))
+        ((fl=? x 2.0)
+         1.0)
+        ((fl>? x 1.0)
+         (let ((x (fl- x 1.0)))
+           (fl* x (Gamma x))))
+        ((fl=? x 1.0)
+         1.0)
+        ((fl=? x 0.0)
+         +inf.0)
+        ((fl<? x 0.0)
+         (if (flinteger? x)    ; pole error
+             +nan.0
+             (fl/ (Gamma (fl+ x 2.0)) x (fl+ x 1.0))))
+        (else
+         (fl/ (polynomial-at x gamma-coefs)))))
+
+;;; Series expansion for 1/Gamma(x), from Abramowitz and Stegun 6.1.34
+
+(define gamma-coefs
+  '(0.0
+    1.0
+    +0.5772156649015329
+    -0.6558780715202538
+    -0.0420026350340952
+    +0.1665386113822915 ; x^5
+    -0.0421977345555443
+    -0.0096219715278770
+    +0.0072189432466630
+    -0.0011651675918591
+    -0.0002152416741149 ; x^10
+    +0.0001280502823882
+    -0.0000201348547807
+    -0.0000012504934821
+    +0.0000011330272320
+    -0.0000002056338417 ; x^15
+    +0.0000000061160950
+    +0.0000000050020075
+    -0.0000000011812746
+    +0.0000000001043427
+    +0.0000000000077823 ; x^20
+    -0.0000000000036968
+    +0.0000000000005100
+    -0.0000000000000206
+    -0.0000000000000054
+    +0.0000000000000014 ; x^25
+    +0.0000000000000001
+    ))
+
+;;; If x >= flgamma:upper-cutoff, then (Gamma x) is +inf.0
+
+(define flgamma:upper-cutoff
+  (do ((x 2.0 (+ x 1.0)))
+      ((flinfinite? (Gamma x))
+       x)))
+
+;;; If x <= flgamma:lower-cutoff, then (Gamma x) is a zero or NaN
+
+(define flgamma:lower-cutoff
+  (do ((x -2.0 (- x 1.0)))
+      ((flzero?
+        (Gamma (fladjacent x 0.0)))
+       x)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; log (Gamma (x))
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Returns two values:
+;;;     log ( |Gamma(x)| )
+;;;     sgn (Gamma(x))
+;;;
+;;; The draft spec is unclear concerning sgn (Gamma(x)),
+;;; but (flsgn x) returns (flcopysign 1.0 x) so I'm assuming
+;;; sgn (Gamma(x)) is +1.0 for positive and -1.0 for negative.
+;;; For real x, Gamma(x) is never actually zero, but it is
+;;; undefined if x is zero or a negative integer.
+
+;;; For small absolute values, this is trivial.
+;;; Abramowitz and Stegun give several asymptotic formulas
+;;; that might be good enough for large values of x.
+;;;
+;;; 6.1.41 :  As x goes to positive infinity, log (Gamma (x)) goes to
+;;;
+;;;     (x - 1/2) log x - x + 1/2 log (2 pi)
+;;;         + 1/(12x) - 1/(360x^3) + 1/(1260x^5) - 1/(1680x^7) + ...
+;;;
+;;; 6.1.48 states a continued fraction.
+
+(define (flloggamma x)
+  (check-flonum! 'flloggamma x)
+  (cond ((flinfinite? x)
+         (if (flpositive? x)
+             (values x 1.0)
+             (values +inf.0 +nan.0)))
+        ((fl>=? x 20.0)
+         (values (eqn6.1.48 x) 1.0))
+        ((fl>? x 0.0)
+         (let ((g (flgamma x)))
+           (values (log g) 1.0)))
+        (else
+         (let ((g (flgamma x)))
+           (values (log (flabs g))
+                   (flcopysign 1.0 g))))))
+
+;;; This doesn't seem to be as accurate as the continued fraction
+;;; of equation 6.1.48, so it's commented out for now.
+
+#;
+(define (eqn6.1.41 x)
+  (let* ((x^2 (fl* x x))
+         (x^3 (fl* x x^2))
+         (x^5 (fl* x^2 x^3))
+         (x^7 (fl* x^2 x^5)))
+    (fl+ (fl* (fl- x 0.5) (fllog x))
+         (fl- x)
+         (fl* 0.5 (fllog fl-2pi))
+         (fl/ (fl* 12.0 x))
+         (fl/ (fl* 360.0 x^3))
+         (fl/ (fl* 1260.0 x^5))
+         (fl/ (fl* 1680.0 x^7)))))
+
+(define (eqn6.1.48 x)
+  (let ((+ fl+)
+        (/ fl/))
+    (+ (fl* (fl- x 0.5) (fllog x))
+       (fl- x)
+       (fl* 0.5 (fllog fl-2pi))
+       (/ #i1/12
+          (+ x
+             (/ #i1/30
+                (+ x
+                   (/ #i53/210
+                      (+ x
+                         (/ #i195/371
+                            (+ x
+                               (/ #i22999/22737
+                                  (+ x
+                                     (/ #i29944523/19733142
+                                        (+ x
+                                           (/ #i109535241009/48264275462
+                                              (+ x)))))))))))))))))
+
+;;; With IEEE double precision, eqn6.1.48 is at least as accurate as
+;;; (log (flgamma x)) starting around x = 20.0
+
+(define flloggamma:upper-threshold 20.0)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Bessel functions
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; FIXME: This isn't as accurate as it should be, it's hard to test
+;;; because it combines so many different algorithms and intervals,
+;;; and it underflows to zero too soon.
+;;;
+;;; FIXME: To reduce discontinuities at the boundaries, results
+;;; near boundaries should be computed as weighted averages of
+;;; the results returned by algorithms used on the two sides of
+;;; the boundary.
+;;;
+;;; FIXME: Several numerical constants, flagged by FIXME comments,
+;;; seem to work for Larceny's double precision but might need to
+;;; be changed for other precisions.  They are unlikely to be
+;;; optimal even for double precision.
+
+(define (flfirst-bessel x n)
+  (define (nan-protected y)
+    (if (flfinite? y) y 0.0))
+  (check-flonum! 'flfirst-bessel x)
+  (cond (c-functions-are-available
+         (jn n x))
+
+        ((< n 0)
+         (let ((result (flfirst-bessel x (- n))))
+           (if (even? n) result (- result))))
+
+        ((< x 0)
+         (let ((result (flfirst-bessel (- x) n)))
+           (if (even? n) result (- result))))
+
+        ((= x +inf.0)
+         0.0)
+
+        (else
+         (case n
+          ((0)    (cond ((fl<? x 4.5)
+                         (eqn9.1.10 x n))
+                        ((fl<? x 155.0)
+                         (eqn9.1.18 x n))
+                        ((fl<? x 1e12)
+                         (eqn9.2.5 x n))
+                        (else
+                         (eqn9.2.1 x n))))
+          ((1)    (cond ((fl<? x 11.0)
+                         (eqn9.1.10-fast x n))
+                        ((fl<? x 300.0)
+                         (eqn9.1.75 x n))
+                        ((fl<? x 1e12)
+                         (eqn9.2.5 x n))
+                        (else
+                         (eqn9.2.1 x n))))
+          ((2)    (cond ((fl<? x 10.0)
+                         (eqn9.1.10-fast x n))
+                        ((fl<? x 1e19)
+                         (eqn9.1.27-first-bessel x n))
+                        (else
+                         ;; FIXME
+                         0.0)))
+          ((3)    (cond ((fl<? x 10.0)
+                         (eqn9.1.10-fast x n))
+                        ((fl<? x 1e6)
+                         (eqn9.1.27-first-bessel x n))
+                        (else
+                         (nan-protected (eqn9.2.5 x n)))))
+          (else   (cond ((fl<? x 12.0)
+                         (nan-protected (eqn9.1.10-fast x n)))
+                        ((fl<? x 150.0)
+                         (nan-protected (if (fl>? (inexact n) x)
+                                            (method9.12ex1 x n)
+                                            (eqn9.1.75 x n))))
+                        ((fl<? x 1e18)
+                         (nan-protected (eqn9.1.27-first-bessel x n)))
+                        (else
+                         ;; FIXME
+                         0.0)))))))
+
+(define (flsecond-bessel x n)
+  (check-flonum! 'flsecond-bessel x)
+  (cond (c-functions-are-available
+         (yn n x))
+
+        ((< n 0)
+         (let ((result (flsecond-bessel x (- n))))
+           (if (even? n) result (- result))))
+
+        ((fl<? x 0.0)
+         +nan.0)
+
+        ((fl=? x 0.0)
+         -inf.0)
+
+        ((fl=? x +inf.0)
+         0.0)
+
+        (else
+         (case n
+          ((0)    (cond ((fl<? x 14.5)
+                         (eqn9.1.13 x 0))
+                        (else
+                         (eqn9.2.6 x 0))))
+          ((1)    (cond ((fl<? x 1e12)
+                         (eqn9.1.16 x n))
+                        (else
+                         (eqn9.2.6 x n))))
+          ((2 3)  (cond (else
+                         (eqn9.1.27-second-bessel x n))))
+          (else   (let ((ynx (eqn9.1.27-second-bessel x n)))
+                    (if (flnan? ynx)
+                        -inf.0
+                        ynx)))))))
+
+;;; For multiples of 1/16:
+;;;
+;;; For n = 0, this agrees with C99 jn for 0 <= x <= 1.5
+;;; and disagrees by no more than 1 bit for 0 <= x <= 2.0.
+;;; For n = 1, this disagrees by no more than 1 bit for 0 <= x <= 2.5.
+;;;
+;;;     n    0 <= x <= xmax    bits
+;;;
+;;;     0    0 <= x <= 1.5      0
+;;;     0    0 <= x <= 2.0      1
+;;;     1    0 <= x <= 2.5      1
+;;;     2    0 <= x <= 3.0      2
+;;;     3    0 <= x <= 2.5      4
+;;;     4    0 <= x <= 2.5      4
+;;;     5    0 <= x <= 3.0      3
+;;;     6    0 <= x <= 4.0      3
+;;;     7    0 <= x <= 6.5      4
+;;;     8    0 <= x <= 2.0      3
+;;;     9    0 <= x <= 1.5      4
+;;;    10    0 <= x <= 4.5      4
+;;;    20    0 <= x <= 3.5      6
+;;;    20    0 <= x <= 6.0      8
+;;;    30    0 <= x <= 1.0      6
+;;;    40    0 <= x <= 1.5      6
+;;;    50    0 <= x <= 1.0      6
+
+
+;;; It should become more accurate for larger n but less accurate for
+;;; larger x.  Should be okay if n > x.
+
+(define (eqn9.1.10 x n)
+  (fl* (inexact (expt (* 0.5 x) n))
+       (polynomial-at (flsquare x)
+                      (cond ((= n 0)
+                             eqn9.1.10-coefficients-0)
+                            ((= n 1)
+                             eqn9.1.10-coefficients-1)
+                            (else
+                             (eqn9.1.10-coefficients n))))))
+
+(define (eqn9.1.10-coefficients n)
+  (define (loop k prev)
+    (if (flzero? (inexact prev))
+        '()
+        (let ((c (/ (* -1/4 prev) k (+ n k))))
+          (cons c (loop (+ k 1) c)))))
+  (let ((c (/ (fact n))))
+    (map inexact (cons c (loop 1 c)))))
+
+(define eqn9.1.10-coefficients-0
+  (eqn9.1.10-coefficients 0))
+
+(define eqn9.1.10-coefficients-1
+  (eqn9.1.10-coefficients 1))
+
+;;; This is faster than using exact arithmetic to compute coefficients
+;;; at call time, and it seems to be about as accurate.
+
+(define (eqn9.1.10-fast x n)
+  (let* ((y (fl* 0.5 x))
+         (y2 (fl- (fl* y y)))
+         (bound (+ 25.0 (inexact n))))
+    (define (loop k n+k)
+      (if (fl>? n+k bound)
+          1.0
+          (fl+ 1.0
+               (fl* (fl/ y2 (fl* k n+k))
+                    (loop (fl+ 1.0 k) (fl+ 1.0 n+k))))))
+    (fl/ (fl* (inexact (expt y n))
+              (loop 1.0 (fl+ 1.0 (inexact n))))
+         (factorial (inexact n)))))
+
+;;; Equation 9.1.11 :
+;;;
+;;;     Y_n(x) = - (1 / (pi (x/2)^n))
+;;;                  \sum_{k=0}^{n-1} ((n - k - 1)!/(k!)) (x^2/4)^k
+;;;              + (2/pi) log (x/2) J_n(x)
+;;;              - ((x/2)^n / pi)
+;;;                  \sum_{k=0}^\infty ((psi(k+1) + psi(n+k+1)) / (k! (n+k)!))
+;;;                                    (x^/4)^k
+;;; where
+;;;
+;;;     psi (1) = - gamma
+;;;     psi (n) = - gamma + \sum_{k=1}^{n-1} (1/k)
+
+;;; Equation 9.1.13 is the special case for Y_0(x) :
+;;;
+;;;     Y_0(x) = (2/pi) (log (x/2) + gamma) J_0(x)
+;;;            + (2/pi) ((x^2/4)^1 / (1!)^2
+;;;                          - (1 + 1/2) (x^2/4)^2 / (2!)^2
+;;;                          + (1 + 1/2 + 1/3) (x^2/4)^3 / (3!)^2
+;;;                          - ...)
+
+(define (eqn9.1.13 x n)
+  (if (not (= n 0)) (error "eqn9.1.13 requires n=0"))
+  (fl* 2.0
+       fl-1/pi
+       (fl+ (fl* (fl+ (fllog (fl/ x 2.0)) fl-euler)
+                 (flfirst-bessel x 0))
+            (polynomial-at (fl* 0.25 x x)
+                           eqn9.1.13-coefficients))))
+
+(define eqn9.1.13-coefficients
+  (map (lambda (k)
+         (cond ((= k 0) 0.0)
+               ((= k 1) 1.0)
+               (else
+                ;; (1 + 1/2 + 1/3 + ... + 1/k) / (k!)^2
+                (let ((c (/ (apply + (map / (cdr (iota (+ k 1)))))
+                            (let ((k! (fact k)))
+                              (* k! k!)))))
+                  (inexact (if (even? k) (- c) c))))))
+       (iota 25))) ; FIXME
+
+;;; Equation 9.1.16 :
+;;;
+;;;     J_{n+1}(x) Y_n(x) - J_n(x) Y_{n+1}(x) = 2 / (pi x)
+;;; so
+;;;     Y_{n+1}(x) = (J_{n+1}(x) Y_n(x) - (2 / (pi x))) / J_n(x)
+
+(define (eqn9.1.16 x n+1)
+  (if (= 0 n+1)
+      (flsecond-bessel x 0)
+      (let ((n (- n+1 1)))
+        (fl/ (fl- (fl* (flfirst-bessel x n+1) (flsecond-bessel x n))
+                  (fl/ 2.0 (fl* fl-pi x)))
+             (flfirst-bessel x n)))))
+
+;;; Equation 9.1.18 :
+;;;
+;;;     J_0(x) = (1 / \pi) \int_0^\pi cos (x sin \theta) d\theta
+;;;            = (1 / \pi) \int_0^\pi cos (x cos \theta) d\theta
+
+(define (eqn9.1.18 x n)
+  (if (> n 0)
+      (flfirst-bessel x n)
+      (fl* fl-1/pi
+           (definite-integral 0.0
+                              fl-pi
+                              (lambda (theta)
+                                (flcos (fl* x (flsin theta))))
+                              128))))
+
+;;; Equation 9.1.27 says
+;;;
+;;; J_{n-1}(x) + J_{n+1}(x) = (2n/x) J_n(x)
+;;;
+;;; J_{n+1}(x) = (2n/x) J_n(x) - J_{n-1}(x)
+;;;
+;;; J_{n-1}(x) = (2n/x) J_n(x) - J_{n+1}(x)
+;;;
+;;; Y_{n-1}(x) + Y_{n+1}(x) = (2n/x) Y_n(x)
+;;;
+;;; Y_{n+1}(x) = (2n/x) Y_n(x) - Y_{n-1}(x)
+;;;
+;;; Y_{n-1}(x) = (2n/x) Y_n(x) - Y_{n+1}(x)
+;;;
+;;; This has too much roundoff error if n > x or if x and n have
+;;; the same magnitude.
+
+(define (eqn9.1.27-first-bessel x n)
+  (eqn9.1.27 flfirst-bessel x n))
+
+(define (eqn9.1.27-second-bessel x n)
+  (eqn9.1.27 flsecond-bessel x n))
+
+(define (eqn9.1.27 f x n0)
+  (define (loop n jn jn-1)
+    (cond ((= n n0)
+           jn)
+          (else
+           (loop (+ n 1)
+                 (fl- (fl* (fl/ (inexact (+ n n)) x) jn)
+                      jn-1)
+                 jn))))
+  (if (<= n0 1)
+      (f x n0)
+      (loop 1 (f x 1) (f x 0))))
+
+;;; For x < n, Abramowitz and Stegun 9.12 Example 1 suggests this method:
+;;;
+;;;     1.  Choose odd N large enough so J_N(x) is essentially zero.
+;;;     2.  Choose an arbitrary trial value, say 1.0, for J_{N-1}(x).
+;;;     3.  Use equation 9.1.27 to estimate the relative values
+;;;         of J_{N-2}(x), J_{N-3}(x), ...
+;;;     4.  Normalize using equation 9.1.46 :
+;;;
+;;;             1 = J_0(x) + 2 J_2(x) + 2 J_4(x) + 2 J_6(x) + ...
+
+(define (method9.12ex1 x n0)
+  (define (loop n jn jn+1 jn0 sumEvens)
+    (if (= n 0)
+        (fl/ jn0 (+ jn sumEvens sumEvens))
+        (let ((jn-1 (fl- (fl/ (fl* 2.0 (inexact n) jn) x) jn+1)))
+          (loop (- n 1)
+                jn-1
+                jn
+                (if (= n n0) jn jn0)
+                (if (even? n) (fl+ jn sumEvens) sumEvens)))))
+  (let* ((n (min 200 (+ n0 20))) ; FIXME
+         (jn+1 (fl/ x (fl* 2.0 (inexact n))))
+         (jn 1.0))
+    (loop (- n 1) jn jn+1 0.0 0.0)))
+
+;;; Equation 9.1.75 states an equality between J_n(x)/J_{n-1}(x)
+;;; and a continued fraction.
+;;;
+;;; Precondition: |x| > 0
+;;;
+;;; This works very well provided (flfirst-bessel x 0) is accurate
+;;; and x is small enough for it to run in reasonable time.
+
+(define (eqn9.1.75 x n)
+  (define k (max 10 (* 2 (exact (flceiling x)))))
+  (define (loop x2 m i)
+    (if (> i k)
+        (fl/ 1.0 (fl* m x2))
+        (fl/ 1.0
+             (fl- (fl* m x2)
+                  (loop x2 (+ m 1.0) (+ i 1))))))
+  (if (and (> n 0)
+           (flpositive? x)
+           (fl<? x 1e3))
+; (if (and (> n 3) (flpositive? x))
+      (fl* (eqn9.1.75 x (- n 1))
+           (loop (fl/ 2.0 x) (inexact n) 0))
+      (flfirst-bessel x n)))
+
+;;; Equation 9.1.89 :
+;;;
+;;;     Y_0(x) = 2/pi (log (x/2) + gamma) J_0(x)
+;;;                 - 4/pi \sum_{k=1}^\infty (-1)^k J_{2k}(x)/k
+;;;
+;;; To reduce roundoff error, the infinite sum is computed
+;;; non-tail-recursively.
+;;;
+;;; FIXME: not used at present, so I've commented it out.
+
+#;
+(define (eqn9.1.89 x n)
+  (define (sum k)
+    (let* ((k2 (+ k k))
+           (j2k (flfirst-bessel x k2))
+           (y (if (even? k) j2k (fl- j2k))))
+      (if (flzero? y)
+          y
+          (fl+ y (sum (+ k 1))))))
+  (if (not (= n 0)) (error "eqn9.1.89 requires n=0"))
+  (fl- (fl* 2.0
+            fl-1/pi
+            (fl+ (fllog (fl/ x 2.0)) fl-euler)
+            (flfirst-bessel x 0))
+       (fl* 4.0 fl-1/pi (sum 1))))
+            
+            
+
+;;; Equation 9.2.1 states an asymptotic approximation that agrees
+;;; with C99 jn to 6 decimal places for n = 0 and x = 1e6.
+
+(define (eqn9.2.1 x n)
+  (fl* (flsqrt (/ 2.0 (fl* fl-pi x)))
+       (flcos (fl- x (fl* fl-pi (fl+ (fl* 0.5 (inexact n)) 0.25))))))
+
+;;; Equation 9.2.2 states an asymptotic approximation for Y_n.
+;;;
+;;; FIXME: not used at present, so I've commented it out.
+
+#;
+(define (eqn9.2.2 x n)
+  (fl* (flsqrt (/ 2.0 (fl* fl-pi x)))
+       (flsin (fl- x (fl* fl-pi (fl+ (fl* 0.5 (inexact n)) 0.25))))))
+
+;;; Equation 9.2.5 : For large x,
+;;;
+;;;     J_n(x) = sqrt (2/(pi x)) [ P(n, x) cos theta - Q (n, x) sin theta ]
+;;;
+;;; where
+;;;
+;;;     theta = x - (n/2 + 1/4) pi
+;;;
+;;; and P(n, x) and Q(n, x) are defined by equations 9.2.9 and 9.2.10.
+
+(define (eqn9.2.5 x n)
+  (let ((theta (fl- x (fl* (fl+ (/ n 2.0) 0.25) fl-pi))))
+    (fl* (flsqrt (fl/ 2.0 (fl* fl-pi x)))
+         (fl- (fl* (eqn9.2.9 n x) (flcos theta))
+              (fl* (eqn9.2.10 n x) (flsin theta))))))
+
+;;; Equation 9.2.6 : For large x,
+;;;
+;;;     Y_n(x) = sqrt (2/(pi x)) [ P(n, x) sin theta + Q (n, x) cos theta ]
+;;;
+;;; where
+;;;
+;;;     theta = x - (n/2 + 1/4) pi
+;;;
+;;; and P(n, x) and Q(n, x) are defined by equations 9.2.9 and 9.2.10.
+
+(define (eqn9.2.6 x n)
+  (let ((theta (fl- x (fl* (fl+ (/ n 2.0) 0.25) fl-pi))))
+    (fl* (flsqrt (fl/ 2.0 (fl* fl-pi x)))
+         (fl+ (fl* (eqn9.2.9 n x) (flsin theta))
+              (fl* (eqn9.2.10 n x) (flcos theta))))))
+
+(define (eqn9.2.9 n x) ; returns P(n, x)
+  (define mu (fl* 4.0 (flsquare (inexact n))))
+  (define (coefficients k2 p fact2k)
+    (let ((c (fl/ p fact2k)))
+      (if (fl>? k2 20.0) ; FIXME
+          (list c)
+          (cons c (coefficients (fl+ k2 2.0)
+                                (fl* p
+                                     (fl- mu (flsquare (fl+ k2 1.0)))
+                                     (fl- mu (flsquare (fl+ k2 3.0))))
+                                (fl* fact2k
+                                     (fl+ k2 1.0)
+                                     (fl+ k2 2.0)))))))
+  (polynomial-at (fl- (fl/ (flsquare (fl* 8.0 x))))
+                 (coefficients 0.0 1.0 1.0)))
+
+(define (eqn9.2.10 n x) ; returns Q(n, x)
+  (define mu (fl* 4.0 (flsquare (inexact n))))
+  (define (coefficients k2+1 p fact2k+1)
+    (let ((c (fl/ p fact2k+1)))
+      (if (fl>? k2+1 20.0) ; FIXME
+          (list c)
+          (cons c (coefficients (fl+ k2+1 2.0)
+                                (fl* p
+                                     (fl- mu (flsquare (fl+ k2+1 2.0)))
+                                     (fl- mu (flsquare (fl+ k2+1 4.0))))
+                                (fl* fact2k+1
+                                     (fl+ k2+1 1.0)
+                                     (fl+ k2+1 2.0)))))))
+  (fl* (fl/ (fl* 8.0 x))
+       (polynomial-at (fl- (fl/ (flsquare (fl* 8.0 x))))
+                      (coefficients 1.0 (fl- mu 1.0) 1.0))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Error functions
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (flerf x)
+  (check-flonum! 'flerf x)
+  (cond ((flnegative? x)
+         (fl- (flerf (fl- x))))
+        ((fl<? x 2.0)
+         (eqn7.1.6 x))
+        ((fl<? x +inf.0)
+         (- 1.0 (eqn7.1.14 x)))
+        ((fl=? x +inf.0)
+         1.0)
+        (else x)))
+
+(define (flerfc x)
+  (check-flonum! 'flerfc x)
+  (cond ((flnegative? x)
+         (fl- 2.0 (flerfc (fl- x))))
+        ((fl<? x 2.0)
+         (eqn7.1.2 x))
+        ((fl<? x +inf.0)
+         (eqn7.1.14 x))
+        ((fl=? x +inf.0)
+         0.0)
+        (else x)))
+
+;;; Equation numbers are from Abramowitz and Stegun.
+
+;;; If the step size is small enough for good accuracy,
+;;; the integration is pretty slow.
+;;;
+;;; FIXME: not used at present, so I've commented it out.
+
+#;
+(define (eqn7.1.1 x)
+  (fl* fl-2/sqrt-pi
+       (definite-integral 0.0 x (lambda (t) (flexp (fl- (flsquare t)))))))
+
+(define (eqn7.1.2 x)
+  (fl- 1.0 (flerf x)))
+
+;;; Equation 7.1.6 :
+;;;
+;;;     erf x = (2 / sqrt(pi))
+;;;             exp(-x^2)
+;;;             \sum_{n=0}^\infty (2^n / (1 * 3 * ... * (2n+1))) x^(2n+1)
+;;;
+;;;           = (2 / sqrt(pi))
+;;;             exp(-x^2)
+;;;             x
+;;;             \sum_{n=0}^\infty (2^n / (1 * 3 * ... * (2n+1))) (x^2)^n
+
+(define (eqn7.1.6 x)
+  (let ((x^2 (flsquare x)))
+    (fl* fl-2/sqrt-pi
+         (flexp (fl- x^2))
+         x
+         (polynomial-at x^2 eqn7.1.6-coefficients))))
+
+(define eqn7.1.6-coefficients
+  (let ()
+    (define (loop n p)
+      (if (> n 32) ; FIXME
+          '()
+          (let ((p (fl* p (inexact (+ (* 2 n) 1)))))
+            (cons (fl/ (inexact (expt 2.0 n)) p)
+                  (loop (+ n 1) p)))))
+    (loop 0 1.0)))
+
+;;; Equation 7.1.14 :
+;;;
+;;;     2 e^(x^2) \int_x^\infty e^(-t^2) dt
+;;;   = 1 / (x + (1/2 / (x + (1 / (x + (3/2 / (x + (2 / (x + ...
+;;;   = x (1/x) (1 / (x + (1/2 / (x + (1 / (x + (3/2 / (x + (2 / (x + ...
+;;;   = x (1 / (x (x + (1/2 / (x + (1 / (x + (3/2 / (x + (2 / (x + ...
+;;;   = x (1 / (x^2 + (1/2 / (1 + (1 / (x^2 + (3/2 / (1 + (2 / (x^2 + ...
+;;;
+;;;     erfc(x) = (2 / sqrt(pi)) \int_x^\infty e^(-t^2) dt
+;;; so
+;;;     erfc(x) = (1 / (sqrt(pi) e^(x^2)))
+;;;                   times the continued fraction
+
+(define (eqn7.1.14 x)
+  (define (continued-fraction x)
+    (fl/ 1.0 (fl+ x (loop 1 0.5))))
+  (define (loop k frac)
+    (if (> k 70) ; FIXME
+        1.0
+        (fl/ frac (fl+ x (loop (+ k 1) (fl+ frac 0.5))))))
+  (fl/ (continued-fraction x)
+       (fl* (flsqrt fl-pi)
+            (flexp (flsquare x)))))

--- a/srfi/README
+++ b/srfi/README
@@ -1,0 +1,24 @@
+This directory contains a portable sample implementation of SRFI 144.
+
+The sample implementation should run without modification in every
+complete implementation of R7RS (small) that uses IEEE-754 double or
+single precision arithmetic for inexact reals.
+
+To show how a Foreign Function Interface (FFI) to C99 math libraries
+could be used to implement some procedures of SRFI 144, the sample
+implementation is configured to use Larceny's FFI when running on an
+x86 processor under Linux or MacOS X.  Although srfi/144.ffi.scm
+uses Larceny's FFI to make many C functions available, the sample
+implementation uses only three of those C functions:
+
+    fma (to implement fl+*)
+    jn  (to implement flfirst-bessel)
+    yn  (to implement flsecond-bessel)
+
+Those are the only C functions that provide a worthwhile advantage
+in either accuracy or speed over the completely portable definitions,
+as measured in Larceny.
+
+The portable implementations of the Bessel functions are far less
+accurate than the C functions jn and yn when the flonum argument is
+on the order of 1e15.

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,47 @@
+This directory contains tests of SRFI 144.  The primary test suite
+uses Larceny's R7RS test framework (tests/scheme/test.sld), which
+was derived from the tests/r6rs/test.sls file in Racket's R6RS test
+suite.  Racket's R6RS test suite is covered by the LGPL, so that
+derivative work is also covered by the LGPL.  The README2 file in
+this directory includes Racket's copyright notice, which gives
+permission to distribute the derivative work.
+
+================================================================
+Testing correctness
+================================================================
+
+The correctness test suite consists of
+
+    tests/scheme/test.sld
+    tests/scheme/flonum.sld
+    tests/scheme/run/flonum.sps
+
+and should run without modification in any complete implementation
+of R7RS (small).  To run it from the parent directory of the tests
+directory, incant something like:
+
+    larceny --path . --r7rs --program tests/scheme/run/flonum.sps
+    sagittarius -c -L . -r7 tests/scheme/run/flonum.sps
+
+Some tests may fail due to minor bugs in current versions of those
+systems, but the current development version of Larceny passes all
+of the correctness tests, with or without using Larceny's FFI.
+
+================================================================
+Testing accuracy and speed
+================================================================
+
+The tests/srfi-144-test.scm file is a Larceny-specific program that
+writes a number of *.data files to the /tmp directory and also
+compares the portable implementations of SRFI 144 procedures against
+the corresponding C99 functions, accessed using Larceny's FFI.  To
+run that program, change the last cond-expand of srfi/144.sld to
+define c-functions-are-available as #f even in Larceny, and incant
+
+    larceny --path . --r7rs --program tests/srfi-144-test.scm
+
+The *.data files assume the C99 functions are perfectly accurate
+(which they are not), and show the rms error for small windows
+around each argument.  The relative error is shown unless the result
+of the C99 function has absolute value less than one, in which case
+the absolute error is used instead.

--- a/tests/README2
+++ b/tests/README2
@@ -1,0 +1,21 @@
+Racket's source code currently resides at
+
+    https://github.com/racket/r6rs
+
+The R6RS tests are r6rs-test/tests/r6rs within that repository:
+
+    https://github.com/racket/r6rs/tree/master/r6rs-test/tests/r6rs
+
+The LICENSE.txt file within the r6rs-test directory says:
+
+r6rs
+Copyright (c) 2010-2014 PLT Design Inc.
+
+This package is distributed under the GNU Lesser General Public
+License (LGPL).  This means that you can link this package into proprietary
+applications, provided you follow the rules stated in the LGPL.  You
+can also modify this package; if you distribute a modified version,
+you must distribute it under the terms of the LGPL, which in
+particular means that you must release the source code for the
+modified software.  See http://www.gnu.org/copyleft/lesser.html
+for more information.

--- a/tests/scheme/flonum.sld
+++ b/tests/scheme/flonum.sld
@@ -1,0 +1,1451 @@
+;;; Copyright (C) William D Clinger (2017).
+;;; 
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use,
+;;; copy, modify, merge, publish, distribute, sublicense, and/or
+;;; sell copies of the Software, and to permit persons to whom the
+;;; Software is furnished to do so, subject to the following
+;;; conditions:
+;;; 
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;; 
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;; OTHER DEALINGS IN THE SOFTWARE. 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Tests these (srfi 144) constants and procedures:
+;;;
+;;;     fl-e
+;;;     fl-1/e
+;;;     fl-e-2
+;;;     fl-e-pi/4
+;;;     fl-log2-e
+;;;     fl-log10-e
+;;;     fl-log-2
+;;;     fl-1/log-2
+;;;     fl-log-3
+;;;     fl-log-pi
+;;;     fl-log-10
+;;;     fl-1/log-10
+;;;     fl-pi
+;;;     fl-1/pi
+;;;     fl-2pi
+;;;     fl-pi/2
+;;;     fl-pi/4
+;;;     fl-2/sqrt-pi
+;;;     fl-pi-squared
+;;;     fl-degree
+;;;     fl-2/pi
+;;;     fl-sqrt-2
+;;;     fl-sqrt-3
+;;;     fl-sqrt-5
+;;;     fl-sqrt-10
+;;;     fl-1/sqrt-2
+;;;     fl-cbrt-2
+;;;     fl-cbrt-3
+;;;     fl-4thrt-2
+;;;     fl-phi
+;;;     fl-log-phi
+;;;     fl-1/log-phi
+;;;     fl-euler
+;;;     fl-e-euler
+;;;     fl-sin-1
+;;;     fl-cos-1
+;;;     fl-gamma-1/2
+;;;     fl-gamma-1/3
+;;;     fl-gamma-2/3
+;;;
+;;;     fl-greatest
+;;;     fl-least
+;;;     fl-epsilon
+;;;     fl-fast-fl+*
+;;;     fl-integer-exponent-zero
+;;;     fl-integer-exponent-nan
+;;;
+;;;     flonum
+;;;     fladjacent
+;;;     flcopysign
+;;;     make-flonum
+;;;
+;;;     flinteger-fraction
+;;;     flexponent
+;;;     flinteger-exponent
+;;;     flnormalized-fraction-exponent
+;;;     flsign-bit
+;;;
+;;;     flonum?
+;;;     fl=?
+;;;     fl<?
+;;;     fl>?
+;;;     fl<=?
+;;;     fl>=?
+;;;     flunordered?
+;;;     flmax
+;;;     flmin
+;;;     flinteger?
+;;;     flzero?
+;;;     flpositive?
+;;;     flnegative?
+;;;     flodd?
+;;;     fleven?
+;;;     flfinite?
+;;;     flinfinite?
+;;;     flnan?
+;;;     flnormalized?
+;;;     fldenormalized?
+;;;
+;;;     fl+
+;;;     fl*
+;;;     fl+*
+;;;     fl-
+;;;     fl/
+;;;     flabs
+;;;     flabsdiff
+;;;     flposdiff
+;;;     flsgn
+;;;     flnumerator
+;;;     fldenominator
+;;;     flfloor
+;;;     flceiling
+;;;     flround
+;;;     fltruncate
+;;;
+;;;     flexp
+;;;     flexp2
+;;;     flexp-1
+;;;     flsquare
+;;;     flsqrt
+;;;     flcbrt
+;;;     flhypot
+;;;     flexpt
+;;;     fllog
+;;;     fllog1+
+;;;     fllog2
+;;;     fllog10
+;;;     make-fllog-base
+;;;
+;;;     flsin
+;;;     flcos
+;;;     fltan
+;;;     flasin
+;;;     flacos
+;;;     flatan
+;;;     flsinh
+;;;     flcosh
+;;;     fltanh
+;;;     flasinh
+;;;     flacosh
+;;;     flatanh
+;;;
+;;;     flquotient
+;;;     flremainder
+;;;     flremquo
+;;;
+;;;     flgamma
+;;;     flloggamma
+;;;     flfirst-bessel
+;;;     flsecond-bessel
+;;;     flerf
+;;;     flerfc
+
+
+(define-library (tests scheme flonum)
+  (export run-flonum-tests)
+  (import (scheme base)
+          (srfi 144)
+          (tests scheme test)
+          (scheme inexact))
+
+  (cond-expand
+   ((library (scheme list))
+    (import (only (scheme list) filter iota)))
+   ((library (srfi 1))
+    (import (only (srfi 1) filter iota)))
+   (else
+    (begin
+     (define (filter p? x)
+       (cond ((null? x)    x)
+             ((p? (car x)) (cons (car x) (filter p? (cdr x))))
+             (else         (filter p? (cdr x)))))
+     (define (iota n)
+       (do ((n (- n 1) (- n 1))
+            (x '() (cons n x)))
+           ((< n 0) x))))))
+
+  (begin
+
+   (define-syntax test-assert
+     (syntax-rules ()
+       ((test-assert expr)
+        (test expr #t))))
+
+   (define-syntax test-deny
+     (syntax-rules ()
+       ((test-assert expr)
+        (test expr #f))))
+
+   (define-syntax test-error
+     (syntax-rules ()
+       ((test-error expr)
+        (test/unspec-or-exn expr &error))))
+
+   (define-syntax test/=
+     (syntax-rules ()
+      ((test/= expr1 expr2)
+       (test expr2 expr1))))
+
+   ;; convenient values for test cases
+
+   (define posints (map flonum '(1 2 3 4 5 10 65536 1e23)))
+   (define nats (cons (flonum 0) posints))
+   (define ints (append (map flonum '(-20 -8 -2 -1)) nats))
+   (define posfracs (map flonum '(1/1000 1/10 1/3 1/2)))
+   (define extremes
+     (list (fl- fl-greatest) (fl- fl-least) fl-least fl-greatest))
+   (define infinities (map flonum (list -inf.0 +inf.0)))
+   (define weird (append infinities (list (flonum +nan.0))))
+
+   (define somereals (append (map flonum
+                                  (list (fl- fl-greatest)
+                                        -10
+                                        (fl- fl-least)
+                                        0))
+                             posfracs
+                             posints))
+   (define somereals+weird
+     (append somereals weird))
+
+   (define negzero (flonum -0.0))
+   (define zero (flonum 0))
+   (define one (flonum 1))
+   (define two (flonum 2))
+
+   (define neginf (flonum -inf.0))
+   (define posinf (flonum +inf.0))
+   (define nan (flonum +nan.0))
+
+
+   (define (run-flonum-tests)
+
+     ;; Mathematical constants
+
+     (test/= 2.718281828459045235360287                    fl-e)
+     (test/= .3678794411714423215955238                    fl-1/e)
+     (test/= 7.389056098930650227230427                    fl-e-2)
+     (test/= 2.1932800507380154566                         fl-e-pi/4)
+     (test/= 1.4426950408889634073599246810018921374266    fl-log2-e)
+     (test/= .4342944819032518276511289                    fl-log10-e)
+     (test/= .6931471805599453094172321                    fl-log-2)
+     (test/= 1.4426950408889634073599246810018921374266    fl-1/log-2)
+     (test/= 1.0986122886681096913952452                   fl-log-3)
+     (test/= 1.144729885849400174143427                    fl-log-pi)
+     (test/= 2.3025850929940456840179915                   fl-log-10)
+     (test/= 0.4342944819032518276511289189166050822944    fl-1/log-10)
+
+     (test/= 3.1415926535897932384626433832795028841972    fl-pi)
+     (test/= 0.3183098861837906715377675267450287240689    fl-1/pi)
+     (test/= 6.283185307179586476925287                    fl-2pi)
+     (test/= 1.570796326794896619231322                    fl-pi/2)
+     (test/= .7853981633974483096156608                    fl-pi/4)
+     (test/= .5641895835477562869480795                    (/ fl-2/sqrt-pi 2))
+     (test/= 9.869604401089358618834491                    fl-pi-squared)
+     (test/= 0.0174532925199432957692369076848861271344    fl-degree)
+     (test/= .3183098861837906715377675                    (/ fl-2/pi 2))
+
+     (test/= 1.4142135623730950488016887242096980785697    fl-sqrt-2)
+     (test/= 1.7320508075688772935274463415058723669428    fl-sqrt-3)
+     (test/= 2.2360679774997896964091736687311762354406    fl-sqrt-5)
+     (test/= 3.1622776601683793319988935444327185337196    fl-sqrt-10)
+     (test/= 1.4142135623730950488016887242096980785697    (* 2 fl-1/sqrt-2))
+     (test/= 1.2599210498948731647672106072782283505703    fl-cbrt-2)
+     (test/= 1.4422495703074083823216383107801095883919    fl-cbrt-3)
+     (test/= 1.1892071150027210667174999705604759152930    fl-4thrt-2)
+
+     (test/= 1.6180339887498948482045868343656381177203    fl-phi)
+     (test/= 0.4812118250596034474977589134243684231352    fl-log-phi)
+     (test/= 2.0780869212350275376013226061177957677422    fl-1/log-phi)
+     (test/= 0.5772156649015328606065120900824024310422    fl-euler)
+     (test/= 1.7810724179901979852365041031071795491696    fl-e-euler)
+
+     (test/= 0.8414709848078965066525023216302989996226    fl-sin-1)
+     (test/= 0.5403023058681397174009366074420766037323    fl-cos-1)
+
+     (test/= 1.7724538509055160272981674833411451827975    fl-gamma-1/2)
+     (test/= 2.6789385347077476336556929409746776441287    fl-gamma-1/3)
+     (test/= 1.3541179394264004169452880281545137855193    fl-gamma-2/3)
+
+     ;; Implementation Constants
+
+     (test-assert (inexact? fl-greatest))
+     (test-assert (inexact? fl-least))
+     (test-assert (inexact? fl-epsilon))
+
+     (test-assert (real? fl-greatest))
+     (test-assert (real? fl-least))
+     (test-assert (real? fl-epsilon))
+
+     (test-assert (flonum? fl-greatest))
+     (test-assert (flonum? fl-least))
+     (test-assert (flonum? fl-epsilon))
+
+     (test-assert (< 0.0
+                     fl-least
+                     fl-epsilon
+                     1.0
+                     (+ 1.0 fl-epsilon)
+                     fl-greatest
+                     posinf))
+     (test-assert (= (* 2 fl-greatest) posinf))
+     (test-assert (= 1 (/ (+ 1 (+ 1.0 fl-epsilon)) 2)))
+     (test-assert (= 0 (/ fl-least 2)))
+
+     (test-assert (boolean? fl-fast-fl+*))
+     (test-assert (exact-integer? fl-integer-exponent-zero))
+     (test-assert (exact-integer? fl-integer-exponent-nan))
+
+     ;; Constructors
+
+     (test (flonum 3) (flonum 3.0))
+     (test (map flonum somereals) somereals)
+     (test (map flonum weird) weird)
+
+     (test (map fladjacent somereals somereals) somereals)
+     (test (map fladjacent weird weird) weird)
+
+     (test (fladjacent zero posinf) fl-least)
+     (test (fladjacent zero neginf) (fl- fl-least))
+     (test (fladjacent fl-least posinf) (fl+ fl-least fl-least))
+     (test (fladjacent fl-least neginf) zero)
+     (test (fladjacent (fl- fl-least) posinf) negzero)
+     (test (fladjacent (fl- fl-least) neginf) (fl* -2.0 fl-least))
+
+     (test (fladjacent zero one) fl-least)
+     (test (fladjacent zero (fl- one)) (fl- fl-least))
+     (test (fladjacent fl-least one) (fl+ fl-least fl-least))
+     (test (fladjacent fl-least (fl- one)) zero)
+     (test (fladjacent (fl- fl-least) one) negzero)
+     (test (fladjacent (fl- fl-least) (fl- one)) (fl* -2.0 fl-least))
+
+     (test (fl- (fladjacent one fl-greatest) one) fl-epsilon)
+     (test (fl- one (fladjacent one zero)) (fl/ fl-epsilon 2.0))
+
+     (test (fladjacent posinf zero) fl-greatest)
+     (test (fladjacent neginf zero) (fl- fl-greatest))
+
+     (test (flcopysign zero posinf) zero)
+     (test (flcopysign zero neginf) negzero)
+     (test (flcopysign zero one) zero)
+     (test (flcopysign zero (fl- one)) negzero)
+     (test (flcopysign one fl-least) one)
+     (test (flcopysign one (fl- fl-greatest)) (fl- one))
+     (test (flcopysign (fl- one) zero) one)
+     (test (map flcopysign somereals somereals) somereals)
+     (test (map flcopysign somereals (map fl- somereals))
+           (map fl- somereals))
+     (test (map flcopysign infinities infinities) infinities)
+     (test (map flcopysign infinities (reverse infinities))
+           (reverse infinities))
+
+     (test (make-flonum zero 12) zero)
+     (test (make-flonum zero -24) zero)
+     (test (make-flonum zero 0) zero)
+     (test (map make-flonum somereals (map (lambda (x) 0) somereals))
+           somereals)
+     (test (map make-flonum somereals (map (lambda (x) 2) somereals))
+           (map (lambda (x) (fl* (flonum 4) x)) somereals))
+     (test (map make-flonum somereals (map (lambda (x) -4) somereals))
+           (map (lambda (x) (fl/ x (flonum 16))) somereals))
+     (test (make-flonum fl-greatest 1) posinf)
+     (test (make-flonum (fl- fl-greatest) 1) neginf)
+     (test (make-flonum fl-greatest -1) (fl/ fl-greatest two))
+     (test (make-flonum (fl- fl-greatest) -1) (fl- (fl/ fl-greatest two)))
+     (test (make-flonum fl-least 1) (fl* two fl-least))
+     (test (make-flonum (fl- fl-least) 1) (fl- (fl* two fl-least)))
+     (test (make-flonum fl-least -1) zero)
+     (test (make-flonum (fl- fl-least) -1) negzero)
+
+     ;; Accessors
+
+     (call-with-values
+      (lambda () (flinteger-fraction 3.75))
+      (lambda (q r)
+        (test q (flonum 3))
+        (test r (flonum .75))))
+
+     (call-with-values
+      (lambda () (flinteger-fraction -3.75))
+      (lambda (q r)
+        (test q (flonum -3))
+        (test r (flonum -.75))))
+
+     (test/= (flonum 12.0)
+             (flexponent (flexpt two (flonum 12))))
+     (test/approx (flexponent (flexpt two (flonum 12.5)))
+                  (flonum 12.5))
+     (test/= (flonum -5.0)
+             (flexponent (flexpt two (flonum -5))))
+     (test/approx (flexponent (flexpt two (flonum -4.5)))
+                  (flonum -4.5))
+
+     (test (flinteger-exponent (flexpt two (flonum 12)))   12)
+     (test (flinteger-exponent (flexpt two (flonum 12.5))) 12)
+     (test (flinteger-exponent (flexpt two (flonum -5)))   -5)
+     (test (flinteger-exponent (flexpt two (flonum -4.5))) -4)
+
+     (let* ((correct?
+             (lambda (x y n)
+               (or (fl=? x (* y (expt two n)))
+                   (fl=? x (* 4.00 y (expt two (- n 2))))
+                   (fl=? x (* 0.25 y (expt two (+ n 2)))))))
+            (test-flnormalized-fraction-exponent
+             (lambda (x)
+               (call-with-values
+                (lambda () (flnormalized-fraction-exponent x))
+                (lambda (y n)
+                  (list (flonum? y)
+                        (exact-integer? n)
+                        (fl<=? (flonum 0.5) (flabs y))
+                        (fl<? (flabs y) one)
+                        (correct? x y n)))))))
+       (test (test-flnormalized-fraction-exponent zero)
+             '(#t #t #f #t #t))
+       (test (test-flnormalized-fraction-exponent negzero)
+             '(#t #t #f #t #t))
+       (test (test-flnormalized-fraction-exponent one)
+             '(#t #t #t #t #t))
+       (test (test-flnormalized-fraction-exponent two)
+             '(#t #t #t #t #t))
+       (test (test-flnormalized-fraction-exponent fl-least)
+             '(#t #t #t #t #t))
+       (test (test-flnormalized-fraction-exponent fl-greatest)
+             '(#t #t #t #t #t))
+       (test (test-flnormalized-fraction-exponent (fl- fl-least))
+             '(#t #t #t #t #t))
+       (test (test-flnormalized-fraction-exponent (fl- fl-greatest))
+             '(#t #t #t #t #t))
+       (test (test-flnormalized-fraction-exponent posinf)
+             '(#t #t #t #t #t))
+       (test (test-flnormalized-fraction-exponent neginf)
+             '(#t #t #t #t #t))
+       (test (test-flnormalized-fraction-exponent nan)
+             '(#t #t #f #f #f))
+
+       )
+
+     (test (flsign-bit one) 0)
+     (test (flsign-bit zero) 0)
+     (test (flsign-bit negzero) 1)
+     (test (flsign-bit (flonum -2)) 1)
+     (test (flsign-bit posinf) 0)
+     (test (flsign-bit neginf) 1)
+
+     ;; Predicates
+
+     (let ((alltrue  (map (lambda (x) #t) somereals))
+           (allfalse (map (lambda (x) #f) somereals)))
+
+       (test (map flonum? somereals) alltrue)
+       (test (map flonum? weird) '(#t #t #t))
+
+       (test-deny   (fl=? zero fl-least))
+       (test-assert (fl=? fl-least fl-least))
+       (test-deny   (fl=? one fl-least))
+       (test-assert (fl=? neginf neginf))
+       (test-deny   (fl=? neginf posinf))
+       (test-deny   (fl=? posinf neginf))
+       (test-assert (fl=? posinf posinf))
+       (test-deny   (fl=? zero nan))
+       (test-deny   (fl=? nan one))
+       (test (map fl=? somereals somereals) alltrue)
+       (test (map fl=? somereals (cdr somereals)) (cdr allfalse))
+       (test (map fl=? (cdr somereals) somereals) (cdr allfalse))
+
+       (test-assert (fl<? zero fl-least))
+       (test-deny   (fl<? fl-least fl-least))
+       (test-deny   (fl<? one fl-least))
+       (test-deny   (fl<? neginf neginf))
+       (test-assert (fl<? neginf posinf))
+       (test-deny   (fl<? posinf neginf))
+       (test-deny   (fl<? posinf posinf))
+       (test-deny   (fl<? zero nan))
+       (test-deny   (fl<? nan one))
+       (test (map fl<? somereals somereals) allfalse)
+       (test (map fl<? somereals (cdr somereals)) (cdr alltrue))
+       (test (map fl<? (cdr somereals) somereals) (cdr allfalse))
+
+       (test-deny   (fl>? zero fl-least))
+       (test-deny   (fl>? fl-least fl-least))
+       (test-assert (fl>? one fl-least))
+       (test-deny   (fl>? neginf neginf))
+       (test-deny   (fl>? neginf posinf))
+       (test-assert (fl>? posinf neginf))
+       (test-deny   (fl>? posinf posinf))
+       (test-deny   (fl>? zero nan))
+       (test-deny   (fl>? nan one))
+       (test (map fl>? somereals somereals) allfalse)
+       (test (map fl>? somereals (cdr somereals)) (cdr allfalse))
+       (test (map fl>? (cdr somereals) somereals) (cdr alltrue))
+
+       (test-assert (fl<=? zero fl-least))
+       (test-assert (fl<=? fl-least fl-least))
+       (test-deny   (fl<=? one fl-least))
+       (test-assert (fl<=? neginf neginf))
+       (test-assert (fl<=? neginf posinf))
+       (test-deny   (fl<=? posinf neginf))
+       (test-assert (fl<=? posinf posinf))
+       (test-deny   (fl<=? zero nan))
+       (test-deny   (fl<=? nan one))
+       (test (map fl<=? somereals somereals) alltrue)
+       (test (map fl<=? somereals (cdr somereals)) (cdr alltrue))
+       (test (map fl<=? (cdr somereals) somereals) (cdr allfalse))
+
+       (test-deny   (fl>=? zero fl-least))
+       (test-assert (fl>=? fl-least fl-least))
+       (test-assert (fl>=? one fl-least))
+       (test-assert (fl>=? neginf neginf))
+       (test-deny   (fl>=? neginf posinf))
+       (test-assert (fl>=? posinf neginf))
+       (test-assert (fl>=? posinf posinf))
+       (test-deny   (fl>=? zero nan))
+       (test-deny   (fl>=? nan one))
+       (test (map fl>=? somereals somereals) alltrue)
+       (test (map fl>=? somereals (cdr somereals)) (cdr allfalse))
+       (test (map fl>=? (cdr somereals) somereals) (cdr alltrue))
+
+       (test-deny   (flunordered? zero fl-least))
+       (test-deny   (flunordered? fl-least fl-least))
+       (test-deny   (flunordered? one fl-least))
+       (test-deny   (flunordered? neginf neginf))
+       (test-deny   (flunordered? neginf posinf))
+       (test-deny   (flunordered? posinf neginf))
+       (test-deny   (flunordered? posinf posinf))
+       (test-assert (flunordered? zero nan))
+       (test-assert (flunordered? nan one))
+       (test (map flunordered? somereals somereals) allfalse)
+       (test (map flunordered? somereals (cdr somereals)) (cdr allfalse))
+       (test (map flunordered? (cdr somereals) somereals) (cdr allfalse))
+
+       )
+
+     (test (flmax) neginf)
+     (test (flmax zero) zero)
+     (test (flmax zero one) one)
+     (test (flmax one zero) one)
+     (test (apply flmax somereals) (car (reverse somereals)))
+
+     (test (flmin) posinf)
+     (test (flmin one) one)
+     (test (flmin zero one) zero)
+     (test (flmin one zero) zero)
+     (test (apply flmin somereals) (car somereals))
+
+     (test (map flinteger? somereals)
+           (map fl=?
+                somereals
+                (map flround somereals)))
+
+     (test-deny   (flzero? neginf))
+     (test-deny   (flzero? (fl- fl-least)))
+     (test-assert (flzero? negzero))
+     (test-assert (flzero? zero))
+     (test-deny   (flzero? fl-least))
+     (test-deny   (flzero? posinf))
+
+     (test-deny   (flpositive? neginf))
+     (test-deny   (flpositive? (fl- fl-least)))
+     (test-deny   (flpositive? negzero))
+     (test-deny   (flpositive? zero))
+     (test-assert (flpositive? fl-least))
+     (test-assert (flpositive? posinf))
+
+     (test-assert (flnegative? neginf))
+     (test-assert (flnegative? (fl- fl-least)))
+     (test-deny   (flnegative? negzero))    ; explicit in SRFI 144
+     (test-deny   (flnegative? zero))
+     (test-deny   (flnegative? fl-least))
+     (test-deny   (flnegative? posinf))
+
+     (test-deny   (flodd? zero))
+     (test-assert (flodd? one))
+
+     (test-assert (fleven? zero))
+     (test-deny   (fleven? one))
+
+     (test (map flfinite? somereals)
+           (map (lambda (x) #t) somereals))
+     (test (map flfinite? weird)
+           (map (lambda (x) #f) weird))
+
+     (test-assert (flinfinite? neginf))
+     (test-assert (flinfinite? posinf))
+     (test-deny   (flinfinite? nan))
+     (test (map flinfinite? somereals)
+           (map (lambda (x) #f) somereals))
+
+     (test-deny   (flnan? neginf))
+     (test-deny   (flnan? posinf))
+     (test-assert (flnan? nan))
+     (test (map flnan? somereals)
+           (map (lambda (x) #f) somereals))
+
+     (test-assert (flnormalized? fl-greatest))
+     (test-deny   (flnormalized? fl-least))
+     (test-deny   (fldenormalized? fl-greatest))
+     (test-assert (fldenormalized? fl-least))
+
+     ;; Arithmetic
+
+     (test (fl+) zero)
+     (test (fl+ zero) zero)
+     (test (flzero? (fl+ negzero)) #t)
+     (test (fl+ one) one)
+     (test (fl+ one one) two)
+     (test (fl+ nan one) nan)
+     (test (fl+ one nan) nan)
+     (test (map fl+ somereals somereals somereals)
+           (map (lambda (x) (fl* (flonum 3) x))
+                somereals))
+     (test (map fl+ infinities infinities) infinities)
+     (test (map flnan?
+                (map fl+ infinities (reverse infinities)))
+           (map (lambda (x) #t) infinities))
+     
+     (test (fl*) one)
+     (test (fl* zero) zero)
+     (test (flzero? (fl* negzero)) #t)
+     (test (fl* one) one)
+     (test (fl* one one) one)
+     (test (fl* nan one) nan)
+     (test (fl* one nan) nan)
+     (test (map fl* somereals somereals somereals)
+           (map (lambda (x) (flonum (expt x 3)))
+                somereals))
+     (test (map fl* infinities infinities)
+           (map (lambda (x) posinf) infinities))
+     (test (map fl* infinities (reverse infinities))
+           (map (lambda (x) neginf) infinities))
+     
+     (let ((three (flonum 3))
+           (four  (flonum 4))
+           (five  (flonum 5))
+           (x23   (flonum 23))
+           (ten11 (flonum (expt 10 11)))
+           (ten12 (flonum (expt 10 12))))
+       (test (fl+* four five three) x23)
+       (test (fl+* ten11 ten12 one)
+             (flonum (+ (* (exact ten11) (exact ten12)) (exact one))))
+       (test (fl+* ten11 ten12 (fl- one))
+             (flonum (+ (* (exact ten11) (exact ten12)) (exact (fl- one)))))
+
+       ;; FIXME: the following test assumes IEEE double precision,
+       ;; in which (expt 10 23) lies exactly halfway between the
+       ;; two nearest flonums.
+
+       (test-deny (fl=? (fl+* ten11 ten12 one)
+                        (fl+* ten11 ten12 (fl- one)))))
+
+     (test-assert (flnan? (fl+* zero posinf one)))
+     (test-assert (flnan? (fl+* zero neginf one)))
+     (test-assert (flnan? (fl+* posinf zero one)))
+     (test-assert (flnan? (fl+* neginf zero one)))
+     (test-assert (flnan? (fl+* zero posinf nan)))
+     (test-assert (flnan? (fl+* zero neginf nan)))
+     (test-assert (flnan? (fl+* posinf zero nan)))
+     (test-assert (flnan? (fl+* neginf zero nan)))
+     (test (fl+* fl-greatest fl-greatest neginf) neginf)
+     (test (fl+* fl-greatest (fl- fl-greatest) posinf) posinf)
+     (test-assert (flnan? (fl+* nan one one)))
+     (test-assert (flnan? (fl+* one nan one)))
+     (test-assert (flnan? (fl+* one one nan)))
+
+     (test (fl- zero) negzero)
+     (test (fl- negzero) zero)
+     (test (fl- one) (flonum -1))
+     (test (fl- one one) zero)
+     (test (fl- nan one) nan)
+     (test (fl- one nan) nan)
+     (test (map fl- somereals somereals somereals)
+           (map (lambda (x) (if (eqv? x zero) zero (fl- x)))
+                somereals))
+     (test (map flnan? (map fl- infinities infinities))
+           '(#t #t))
+     (test (map fl- infinities (reverse infinities))
+           infinities)
+     
+     (test (fl/ zero) posinf)
+     (test (fl/ negzero) neginf)
+     (test (fl/ one) one)
+     (test (fl/ one one) one)
+     (test (fl/ nan one) nan)
+     (test (fl/ one nan) nan)
+     (test (map fl/ somereals somereals somereals)
+           (map (lambda (x) (if (flzero? x) (fl/ zero zero) (fl/ x)))
+                somereals))
+     (test (map flnan? (map fl/ infinities infinities))
+           '(#t #t))
+     (test (map flnan? (map fl/ infinities (reverse infinities)))
+           '(#t #t))
+     
+     (test (flabs zero) zero)
+     (test (flabs negzero) zero)
+     (test (flabs one) one)
+     (test (flabs (flonum -5.25)) (flonum 5.25))
+     
+     (test (flabsdiff zero one) one)
+     (test (flabsdiff one zero) one)
+     (test (flabsdiff one one) zero)
+     (test (flabsdiff posinf neginf) posinf)
+     (test (flabsdiff neginf posinf) posinf)
+#|
+     (test (flposdiff zero one) zero)
+     (test (flposdiff one zero) one)
+     (test (flposdiff one one) zero)
+     (test (flposdiff posinf neginf) posinf)
+     (test (flposdiff neginf posinf) posinf)
+|#
+     (test (flsgn posinf) one)
+     (test (flsgn neginf) (fl- one))
+     (test (flsgn zero) one)
+     (test (flsgn negzero) (fl- one))
+     (test (flsgn two) one)
+     (test (flsgn (fl- two)) (fl- one))
+
+     (test (flnumerator (flonum 2.25)) (flonum 9))
+     (test (fldenominator (flonum 2.25)) (flonum 4))
+     (test (flnumerator (flonum -2.25)) (flonum -9))
+     (test (fldenominator (flonum -2.25)) (flonum 4))
+     (test (map flnumerator ints) ints)
+     (test (map fldenominator ints)
+           (map (lambda (x) one) ints))
+     (test (map flnumerator weird) weird)
+     (test (map fldenominator infinities) (list one one))
+     (test-assert (flnan? (flnumerator nan)))
+     (test-assert (flnan? (fldenominator nan)))
+
+     (test (flfloor    (flonum -3.125)) (flonum -4))
+     (test (flceiling  (flonum -3.125)) (flonum -3))
+     (test (flround    (flonum -3.125)) (flonum -3))
+     (test (fltruncate (flonum -3.125)) (flonum -3))
+
+     (test (flfloor    (flonum -3.75)) (flonum -4))
+     (test (flceiling  (flonum -3.75)) (flonum -3))
+     (test (flround    (flonum -3.75)) (flonum -4))
+     (test (fltruncate (flonum -3.75)) (flonum -3))
+
+     (test (flfloor    (flonum -3.5)) (flonum -4))
+     (test (flceiling  (flonum -3.5)) (flonum -3))
+     (test (flround    (flonum -3.5)) (flonum -4))
+     (test (fltruncate (flonum -3.5)) (flonum -3))
+
+     (test (map flfloor    ints) ints)
+     (test (map flceiling  ints) ints)
+     (test (map flround    ints) ints)
+     (test (map fltruncate ints) ints)
+
+     (test (map flfloor    posfracs) (map (lambda (x) zero) posfracs))
+     (test (map flceiling  posfracs) (map (lambda (x) one) posfracs))
+     (test (map flround    posfracs) (map (lambda (x) zero) posfracs))
+     (test (map fltruncate posfracs) (map (lambda (x) zero) posfracs))
+
+     (test (map flfloor    weird) weird)
+     (test (map flceiling  weird) weird)
+     (test (map flround    weird) weird)
+     (test (map fltruncate weird) weird)
+
+     ;; Exponents and logarithms
+
+     (test (flexp negzero) one)
+     (test (flexp zero) one)
+     (test (flexp one) fl-e)
+     (test/approx (flexp (fl- one)) fl-1/e)
+     (test/approx (flexp two) fl-e-2)
+     (test/approx (flexp fl-pi/4) fl-e-pi/4)
+     (test (flexp posinf) posinf)
+     (test (flexp fl-greatest) posinf)
+     (test/approx (flexp fl-least) one)
+     (test/approx (flexp (fl- fl-greatest)) zero)
+     (test/approx (flexp neginf) zero)
+
+     (test (fl+ one (flexp-1 negzero)) one)
+     (test (fl+ one (flexp-1 zero)) one)
+     (test (fl+ one (flexp-1 one)) fl-e)
+     (test/approx (fl+ one (flexp-1 (fl- one))) fl-1/e)
+     (test/approx (fl+ one (flexp-1 two)) fl-e-2)
+     (test/approx (fl+ one (flexp-1 fl-pi/4)) fl-e-pi/4)
+     (test (fl+ one (flexp-1 posinf)) posinf)
+     (test (fl+ one (flexp-1 fl-greatest)) posinf)
+     (test/approx (fl+ one (flexp-1 fl-least)) one)
+     (test/approx (fl+ one (flexp-1 (fl- fl-greatest))) zero)
+     (test/approx (fl+ one (flexp-1 neginf)) zero)
+
+     (test (flexp2 negzero) one)
+     (test (flexp2 zero) one)
+     (test (flexp2 one) two)
+     (test (flexp2 (fl- one)) (fl/ two))
+     (test (flexp2 two) (fl* two two))
+     (test/approx (flexp2 fl-log2-e) fl-e)
+     (test/approx (flexp2 fl-log2-e) fl-e)
+     (test (flexp2 posinf) posinf)
+     (test (flexp2 fl-greatest) posinf)
+     (test/approx (flexp2 fl-least) one)
+     (test/approx (flexp2 (fl- fl-greatest)) zero)
+     (test/approx (flexp2 neginf) zero)
+
+     (test (flsquare zero) zero)
+     (test (flsquare one) one)
+     (test (flsquare two) (fl+ two two))
+     (test/approx (flsquare fl-sqrt-2) two)
+     (test/approx (flsquare fl-sqrt-3) (flonum 3))
+     (test/approx (flsquare fl-sqrt-5) (flonum 5))
+     (test/approx (flsquare fl-sqrt-10) (flonum 10))
+     (test (flsquare (flonum -5)) (flonum 25))
+     (test (flsquare neginf) posinf)
+     (test (flsquare posinf) posinf)
+
+     (test (flsqrt zero) zero)
+     (test (flsqrt one) one)
+     (test/approx (flsqrt two) fl-sqrt-2)
+     (test/approx (flsqrt (flonum 3)) fl-sqrt-3)
+     (test/approx (flsqrt (flonum 5)) fl-sqrt-5)
+     (test/approx (flsqrt (flonum 10)) fl-sqrt-10)
+     (test/approx (flsqrt (flonum 698)) (flonum 26.41968963))
+     (test (flsqrt posinf) posinf)
+
+     (test (flcbrt zero) zero)
+     (test (flcbrt one) one)
+     (test/approx (flcbrt two) fl-cbrt-2)
+     (test/approx (flcbrt (flonum 3)) fl-cbrt-3)
+     (test/approx (flcbrt (flonum 698)) (flonum 8.870575722))
+     (test/approx (flcbrt (flonum 11.390625)) (flonum 2.25))
+     (test/approx (flcbrt (flonum -11.390625)) (flonum -2.25))
+     (test (flcbrt posinf) posinf)
+     (test (flcbrt neginf) neginf)
+
+     (test (flhypot zero zero) zero)
+     (test (flhypot zero one) one)
+     (test/approx (flhypot two one) fl-sqrt-5)
+     (test/approx (flhypot (fl- two) one) fl-sqrt-5)
+     (test/approx (flhypot two (fl- one)) fl-sqrt-5)
+     (test/approx (flhypot (fl- two) (fl- one)) fl-sqrt-5)
+     (test/approx (flhypot (fl/ fl-greatest two) (fl/ fl-greatest two))
+                  (fl/ fl-greatest fl-sqrt-2))
+     (test (flhypot zero posinf) posinf)
+     (test (flhypot neginf zero) posinf)
+
+     (test (flexpt two zero) one)
+     (test (flexpt two one) two)
+     (test (flexpt two two) (flonum 4))
+     (test/approx (flexpt two (fl/ two)) fl-sqrt-2)
+     (test/approx (flexpt (flonum 441) (flonum 10))
+                  (flonum 2.782184294e26))
+     (test/approx (flexpt (flonum 441) (fl/ (flonum 5)))
+                  (flonum 3.379774445))
+     (for-each (lambda (x)
+                 (for-each (lambda (frac)
+                             (test/approx (flexpt (flexpt x frac) (fl/ frac))
+                                          x))
+                           posfracs))
+               (filter flpositive? somereals))
+
+     (test (fllog zero) neginf)
+     (test (fllog one) zero)
+     (test/approx (fllog two) fl-log-2)
+     (test/approx (fllog (flonum 3)) fl-log-3)
+     (test/approx (fllog fl-pi) fl-log-pi)
+     (test/approx (fllog (flonum 10)) fl-log-10)
+     (test (fllog posinf) posinf)
+     (for-each (lambda (x)
+                 (test/approx (flexp (fllog x)) x))
+               (filter flpositive? somereals))
+
+     (test (fllog2 zero) neginf)
+     (test (fllog2 one) zero)
+     (test (fllog2 two) one)
+     (test/approx (fllog2 fl-e) fl-log2-e)
+     (test (fllog2 posinf) posinf)
+     (for-each (lambda (x)
+                 (test/approx (flexpt two (fllog2 x)) x))
+               (filter flpositive? somereals))
+
+     (test (fllog10 zero) neginf)
+     (test (fllog10 one) zero)
+     (test/approx (fllog10 fl-e) fl-log10-e)
+     (test (fllog10 (flonum 10)) one)
+     (test (fllog10 posinf) posinf)
+     (for-each (lambda (x)
+                 (test/approx (flexpt (flonum 10) (fllog10 x)) x))
+               (filter flpositive? somereals))
+
+     (test-assert (flpositive? (fllog1+ fl-least)))
+     (test (fllog1+ (fl- zero one)) neginf)
+     (test (fllog1+ (fl- one one)) zero)
+     (test/approx (fllog1+ (fl- two one)) fl-log-2)
+     (test/approx (fllog1+ (fl- (flonum 3) one)) fl-log-3)
+     (test/approx (fllog1+ (fl- fl-pi one)) fl-log-pi)
+     (test/approx (fllog1+ (fl- (flonum 10) one)) fl-log-10)
+     (test (fllog1+ (fl- posinf one)) posinf)
+     (for-each (lambda (x)
+                 (test/approx (flexp (fllog1+ (fl- x one))) x))
+               (filter flpositive? somereals))
+
+     (test/approx ((make-fllog-base 2) fl-e) fl-log2-e)
+     (test/approx ((make-fllog-base 10) fl-e) fl-log10-e)
+;    (test/approx ((make-fllog-base fl-e) two) fl-log-2)
+     (for-each (lambda (base)
+                 (let ((f (make-fllog-base base)))
+                   (for-each (lambda (x)
+                               (test/approx (flexpt (flonum base) (f x)) x))
+                             (filter positive? somereals))))
+               '(3 7 19))
+
+     ;; Trigonometric functions
+
+     (test/approx (flsin zero)           zero)
+     (test/approx (flcos zero)           one)
+     (test/approx (fltan zero)           zero)
+     (test/approx (flsin (flonum 0.2))   0.19866933079506121545941)
+     (test/approx (flcos (flonum 0.2))   0.98006657784124163112420)
+     (test/approx (flsin (flonum 0.5))   0.47942553860420300027329)
+     (test/approx (flcos (flonum 0.5))   0.87750256189037271611628)
+     (test/approx (flsin (flonum 0.7))   0.64421768723769105367261)
+     (test/approx (flcos (flonum 0.7))   0.76484218728448842625586)
+     (test/approx (flsin fl-pi/4)        fl-1/sqrt-2)
+     (test/approx (flcos fl-pi/4)        fl-1/sqrt-2)
+     (test/approx (flsin one)            0.84147098480789651665250)
+     (test/approx (flcos one)            0.54030230586813971740094)
+     (test/approx (flsin fl-pi/2)        one)
+     (test/approx (flcos fl-pi/2)        zero)
+     (test/approx (flsin two)            0.90929742682568169539602)
+     (test/approx (flcos two)            -0.41614683654714238699757)
+     (test/approx (flsin (flonum 3))     0.14112000805986722210074)
+     (test/approx (flcos (flonum 3))     -0.98999249660044545727157)
+     (test/approx (flsin fl-pi)          zero)
+     (test/approx (flcos fl-pi)          (fl- one))
+     (test/approx (flsin fl-2pi)         zero)
+     (test/approx (flcos fl-2pi)         one)
+     (test/approx (flsin (flonum 35))    -0.42818266949615100440675)
+     (test/approx (flcos (flonum 35))    -0.90369220509150675984730)
+
+     (for-each (lambda (x)
+                 (test/approx (flsin x) (fl- (flsin (fl- x))))
+                 (test/approx (flcos x) (flcos (fl- fl-2pi x)))
+                 (test/approx (fltan x) (fl/ (flsin x) (flcos x)))
+                 (test/approx (flhypot (flsin x) (flcos x)) one))
+               (filter (lambda (x)
+                         (and (flnormalized? x)
+                              (fl<? (flabs x) (flonum 10000))))
+                       (append somereals posfracs)))
+
+     (for-each (lambda (x)
+                 (test/approx (flsin (flasin x))     x)
+                 (test/approx (flcos (flacos x))     x))
+               (filter (lambda (x) (fl<=? (fl- one) x one))
+                       (append somereals posfracs)))
+
+
+     (let ((xs (filter (lambda (x)
+                         (and (flnormalized? x)
+                              (fl<? (flabs x) (flonum 10000))))
+                       (append somereals posfracs))))
+       (for-each (lambda (x)
+                   (let ((theta (flatan x)))
+                     (test/approx (fl/ (flsin theta) (flcos theta)) x))
+                   (for-each (lambda (y)
+                               (let ((theta (flatan x)))
+                                 (test/approx (flatan (flsin theta)
+                                                      (flcos theta))
+                                              theta)))
+                             xs))
+                 xs))
+
+     (test/approx (flsinh zero)           zero)
+     (test/approx (flcosh zero)           one)
+     (test/approx (flsinh (flonum 0.2))   0.201336003)
+     (test/approx (flcosh (flonum 0.2))   1.020066756)
+     (test/approx (flsinh (flonum 0.5))   0.521095305)
+     (test/approx (flcosh (flonum 0.5))   1.127625965)
+     (test/approx (flsinh (flonum 0.7))   0.758583702)
+     (test/approx (flcosh (flonum 0.7))   1.255169006)
+     (test/approx (flsinh one)            1.175201194)
+     (test/approx (flcosh one)            1.543080635)
+     (test/approx (flsinh two)            3.626860408)
+     (test/approx (flcosh two)            3.762195691)
+     (test/approx (flsinh (flonum 3))     10.017874927)
+     (test/approx (flcosh (flonum 3))     10.067661996)
+     (test/approx (flsinh (flonum 10))    11013.232874703)
+     (test/approx (flcosh (flonum 10))    11013.232920103)
+
+     (for-each (lambda (x)
+                 (test/approx (flasinh (flsinh x)) x)
+                 (test/approx (flacosh (flcosh x)) (flabs x))
+                 (test/approx (flatanh (fltanh x)) x))
+               (filter (lambda (x)
+                         (fl<? (flabs x) (flonum 100)))
+                       (append somereals posfracs (map fl- posfracs))))
+
+     ;; Integer division
+
+     (test (flquotient  (flonum 9.75) (flonum 0.5))     (flonum 19))
+     (test (flremainder (flonum 9.75) (flonum 0.5))     (flonum 0.25))
+     (test (flquotient  (flonum -9.75) (flonum 0.5))    (flonum -19))
+     (test (flremainder (flonum -9.75) (flonum 0.5))    (flonum -0.25))
+     (test (flquotient  (flonum 9.75) (flonum -0.5))    (flonum -19))
+     (test (flremainder (flonum 9.75) (flonum -0.5))    (flonum 0.25))
+     (test (flquotient  (flonum -9.75) (flonum -0.5))   (flonum 19))
+     (test (flremainder (flonum -9.75) (flonum -0.5))   (flonum -0.25))
+
+     (let ((f (lambda (x y)
+                (call-with-values
+                 (lambda () (flremquo x y))
+                 (lambda (r q)
+                   (list r (modulo q 8)))))))
+
+       (test (f (flonum 15.875) (flonum 0.5))
+             (list (flonum -0.125) 0))
+       (test (f (flonum 16.000) (flonum 0.5))
+             (list (flonum +0.000) 0))
+       (test (f (flonum 16.125) (flonum 0.5))
+             (list (flonum +0.125) 0))
+       (test (f (flonum 16.250) (flonum 0.5))
+             (list (flonum +0.250) 0))
+
+       (test (f (flonum 16.875) (flonum 0.5))
+             (list (flonum -0.125) 2))
+       (test (f (flonum 17.000) (flonum 0.5))
+             (list (flonum +0.000) 2))
+       (test (f (flonum 17.125) (flonum 0.5))
+             (list (flonum +0.125) 2))
+       (test (f (flonum 17.250) (flonum 0.5))
+             (list (flonum +0.250) 2))
+
+       (test (f (flonum 17.875) (flonum 0.5))
+             (list (flonum -0.125) 4))
+       (test (f (flonum 18.000) (flonum 0.5))
+             (list (flonum +0.000) 4))
+       (test (f (flonum 18.125) (flonum 0.5))
+             (list (flonum +0.125) 4))
+       (test (f (flonum 18.250) (flonum 0.5))
+             (list (flonum +0.250) 4))
+
+       (test (f (flonum 18.875) (flonum 0.5))
+             (list (flonum -0.125) 6))
+       (test (f (flonum 19.000) (flonum 0.5))
+             (list (flonum +0.000) 6))
+       (test (f (flonum 19.125) (flonum 0.5))
+             (list (flonum +0.125) 6))
+       (test (f (flonum 19.250) (flonum 0.5))
+             (list (flonum +0.250) 6))
+
+       (test (f (flonum 15.375) (flonum 0.5))
+             (list (flonum -0.125) 7))
+       (test (f (flonum 16.500) (flonum 0.5))
+             (list (flonum +0.000) 1))
+       (test (f (flonum 16.625) (flonum 0.5))
+             (list (flonum +0.125) 1))
+       (test (f (flonum 16.750) (flonum 0.5))
+             (list (flonum -0.250) 2))
+
+       (test (f (flonum 16.375) (flonum 0.5))
+             (list (flonum -0.125) 1))
+       (test (f (flonum 17.500) (flonum 0.5))
+             (list (flonum +0.000) 3))
+       (test (f (flonum 17.625) (flonum 0.5))
+             (list (flonum +0.125) 3))
+       (test (f (flonum 17.750) (flonum 0.5))
+             (list (flonum -0.250) 4))
+
+       (test (f (flonum 17.375) (flonum 0.5))
+             (list (flonum -0.125) 3))
+       (test (f (flonum 18.500) (flonum 0.5))
+             (list (flonum +0.000) 5))
+       (test (f (flonum 18.625) (flonum 0.5))
+             (list (flonum +0.125) 5))
+       (test (f (flonum 38.750) (flonum 0.5))
+             (list (flonum -0.250) 6))
+
+       (test (f (flonum 18.375) (flonum 0.5))
+             (list (flonum -0.125) 5))
+       (test (f (flonum 19.500) (flonum 0.5))
+             (list (flonum +0.000) 7))
+       (test (f (flonum 19.625) (flonum 0.5))
+             (list (flonum +0.125) 7))
+       (test (f (flonum 19.750) (flonum 0.5))
+             (list (flonum -0.250) 0))
+
+       )
+
+     ;; Special functions
+
+     (test/approx (flgamma (flonum 0.5)) fl-gamma-1/2)
+     (test/approx (flgamma (flonum #i1/3)) fl-gamma-1/3)
+     (test/approx (flgamma (flonum #i2/3)) fl-gamma-2/3)
+     (test/approx (flgamma (flonum 0.75)) (flonum 1.2254167024))
+     (test (flgamma one) one)
+     (test/approx (flgamma (flonum 1.25)) (flonum 0.9064024771))
+     (test/approx (flgamma (flonum 1.38)) (flonum 0.8885371494))
+     (test/approx (flgamma (flonum 1.50)) (fl/ (flsqrt fl-pi) two))
+     (test (flgamma two) one)
+     (test/approx (flgamma (flonum 11)) (flonum 3628800))
+     (test/approx (flgamma (flonum 11.5))
+                  (* 10.5 9.5 8.5 7.5 6.5 5.5 4.5 3.5 2.5 1.5 0.5
+                     fl-gamma-1/2))
+     (test/approx (flgamma (flonum 1.3))
+                  (* 0.3 -0.7 -1.7 -2.7 -3.7 -4.7 -5.7 -6.7
+                     (flgamma (flonum -6.7))))
+     (test/approx (flgamma (flonum 1.3))
+                  (* 0.3 -0.7 -1.7 -2.7 -3.7 -4.7 -5.7 -6.7 -7.7
+                     (flgamma (flonum -7.7))))
+     (test/approx (flgamma (flonum 76.5))
+                  (flonum 2.1592564e110))
+     (test/approx (flgamma (flonum 100))
+                  (flonum 9.3326215444e155))
+
+     (let* ((f (lambda (x)
+                 (call-with-values
+                  (lambda () (flloggamma x))
+                  list)))
+            (g (lambda (x) (car (f x))))
+            (s (lambda (x) (cadr (f x)))))
+       (test/approx (g (flonum 0.5)) (log fl-gamma-1/2))
+       (test/approx (g (flonum #i1/3)) (log fl-gamma-1/3))
+       (test/approx (g (flonum #i2/3)) (log fl-gamma-2/3))
+       (test/approx (g (flonum 0.75)) (log (flonum 1.2254167024)))
+       (test/approx (g one) (log one))
+       (test/approx (g (flonum 1.25)) (log (flonum 0.9064024771)))
+       (test/approx (g (flonum 1.38)) (log (flonum 0.8885371494)))
+       (test/approx (g (flonum 1.50)) (log (fl/ (flsqrt fl-pi) two)))
+       (test/approx (g two) (log one))
+       (test/approx (g (flonum 11)) (log (flonum 3628800)))
+       (test/approx (g (flonum 1000))
+                    (apply + (map log (cdr (iota 1000)))))
+       (test/approx (g (flonum -0.5))
+                    (log (flabs (flgamma (flonum -0.5)))))
+       (test/approx (g (flonum -49.2))
+                    (log (flabs (flgamma (flonum -49.2)))))
+       (test/approx (g (flonum -50.3))
+                    (log (flabs (flgamma (flonum -50.3)))))
+       (test/approx (g (flonum -100.5))
+                    (log (flabs (flgamma (flonum -100.5)))))
+       (test/approx (g posinf) posinf)
+       (test/unspec-or-exn (g neginf) &error)
+       (test/unspec-or-exn (g zero) &error)
+       (test/unspec-or-exn (g nan) &error)
+
+       (test (s (flonum 0.5))   one)
+       (test (s (flonum #i1/3)) one)
+       (test (s (flonum #i2/3)) one)
+       (test (s (flonum 0.75))  one)
+       (test (s one)            one)
+       (test (s (flonum 1.25))  one)
+       (test (s (flonum 1.38))  one)
+       (test (s (flonum 1.50))  one)
+       (test (s two)            one)
+       (test (s (flonum 11))    one)
+       (test (s (flonum 1000))  one)
+       (test (s (flonum -0.5))  (fl- one))
+       (test (s (flonum -49.2)) one)
+       (test (s (flonum -50.3)) (fl- one))
+       (test (s (flonum -999.5)) one)
+       (test (s (flonum -1000.5)) (fl- one))
+       )
+
+     (test (flfirst-bessel zero 0) one)
+     (test (flfirst-bessel zero 1) zero)
+     (test (flfirst-bessel zero 2) zero)
+     (test (flfirst-bessel zero 3) zero)
+     (test (flfirst-bessel zero 4) zero)
+     (test (flfirst-bessel zero 5) zero)
+     (test (flfirst-bessel zero 6) zero)
+     (test (flfirst-bessel zero 7) zero)
+     (test (flfirst-bessel zero 8) zero)
+     (test (flfirst-bessel zero 9) zero)
+
+     (test/approx (flfirst-bessel (flonum 0.4) 0)
+                  (flonum 0.960398226659563))
+     (test/approx (flfirst-bessel (flonum 0.4) 1)
+                  (flonum 0.1960265780))
+     (test/approx (flfirst-bessel (flonum 0.4) 2)
+                  (flonum 0.0197346631))
+     (test/approx (flfirst-bessel (flonum 0.4) 3)
+                  (flonum 1.3201e-3))
+     (test/approx (flfirst-bessel (flonum 0.4) 4)
+                  (flonum 6.6135e-5))
+     (test/approx (flfirst-bessel (flonum 0.4) 5)
+                  (flonum 2.6489e-6))
+     (test/approx (flfirst-bessel (flonum 0.4) 6)
+                  (flonum 8.8382e-8))
+     (test/approx (flfirst-bessel (flonum 0.4) 7)
+                  (flonum 2.5270e-9))
+     (test/approx (flfirst-bessel (flonum 0.4) 8)
+                  (flonum 6.3210e-11))
+     (test/approx (flfirst-bessel (flonum 0.4) 9)
+                  (flonum 1.4053e-12))
+
+     (test/approx (flfirst-bessel one 0)
+                  (flonum 0.765197686557967))
+     (test/approx (flfirst-bessel one 1)
+                  (flonum 0.4400505857))
+     (test/approx (flfirst-bessel one 2)
+                  (flonum 0.1149034849))
+     (test/approx (flfirst-bessel one 3)
+                  (flonum 1.9563e-2))
+     (test/approx (flfirst-bessel one 4)
+                  (flonum 2.4766e-3))
+     (test/approx (flfirst-bessel one 5)
+                  (flonum 2.4976e-4))
+     (test/approx (flfirst-bessel one 6)
+                  (flonum 2.0938e-5))
+     (test/approx (flfirst-bessel one 7)
+                  (flonum 1.5023e-6))
+     (test/approx (flfirst-bessel one 8)
+                  (flonum 9.4223e-8))
+     (test/approx (flfirst-bessel one 9)
+                  (flonum 5.2493e-9))
+
+     (test/approx (flfirst-bessel (flonum 17) 0)
+                  (flonum -0.169854252151184))
+     (test/approx (flfirst-bessel (flonum 17) 1)
+                  (flonum -0.0976684928))
+     (test/approx (flfirst-bessel (flonum 17) 2)
+                  (flonum 0.1583638412))
+     (test/approx (flfirst-bessel (flonum 17) 3)
+                  (flonum 0.13493))
+     (test/approx (flfirst-bessel (flonum 17) 4)
+                  (flonum -0.11074))
+     (test/approx (flfirst-bessel (flonum 17) 5)
+                  (flonum -0.18704))
+     (test/approx (flfirst-bessel (flonum 17) 6)
+                  (flonum 0.0007153))
+     (test/approx (flfirst-bessel (flonum 17) 7)
+                  (flonum 0.18755))
+     (test/approx (flfirst-bessel (flonum 17) 8)
+                  (flonum 0.15374))
+     (test/approx (flfirst-bessel (flonum 17) 9)
+                  (flonum -0.04286))
+
+     (test/approx (flfirst-bessel (flonum 50) 0)
+                  (flonum +5.581232767e-2))
+     (test/approx (flfirst-bessel (flonum 50) 1)
+                  (flonum -9.751182813e-2))
+     (test/approx (flfirst-bessel (flonum 50) 2)
+                  (flonum -5.971280079e-2))
+     (test/approx (flfirst-bessel (flonum 50) 3)
+                  (flonum +9.273480406e-2))
+     (test/approx (flfirst-bessel (flonum 50) 4)
+                  (flonum +7.084097728e-2))
+     (test/approx (flfirst-bessel (flonum 50) 5)
+                  (flonum -8.140024770e-2))
+     (test/approx (flfirst-bessel (flonum 50) 6)
+                  (flonum -8.712102682e-2))
+     (test/approx (flfirst-bessel (flonum 50) 7)
+                  (flonum +6.049120126e-2))
+     (test/approx (flfirst-bessel (flonum 50) 8)
+                  (flonum +1.040585632e-1))
+     (test/approx (flfirst-bessel (flonum 50) 9)
+                  (flonum -2.719246104e-2))
+
+     (let ((f (lambda (n x y)
+                (test/approx (fl/ (flfirst-bessel x n) y)
+                             (flexpt x (flonum n))))))
+       (f 10 zero 2.69114446e-10)
+       (f 11 zero 1.22324748e-11)
+       (f 20 zero 3.91990e-25)
+       (f 21 zero 9.33311e-27)
+       (f 10 (flonum 8) 0.56593704e-10)
+       (f 11 (flonum 8) 0.29798448e-11)
+       (f 20 (flonum 8) 1.80462e-25)
+       (f 21 (flonum 8) 4.45624e-27))
+
+     (test/approx (flfirst-bessel (flonum 10) 10)  2.074861066e-1)
+     (test/approx (flfirst-bessel (flonum 10) 15)  4.507973144e-3)
+     (test/approx (flfirst-bessel (flonum 10) 20)  1.151336925e-5)
+     (test/approx (flfirst-bessel (flonum 10) 50)  1.784513608e-30)
+     (test/approx (flfirst-bessel (flonum 10) 100) 6.597316064e-89)
+
+     (test/approx (flfirst-bessel (flonum 100) 10)  -5.473217694e-2)
+     (test/approx (flfirst-bessel (flonum 100) 15)  +1.519812122e-2)
+     (test/approx (flfirst-bessel (flonum 100) 20)  +6.221745850e-2)
+     (test/approx (flfirst-bessel (flonum 100) 50)  -3.869833973e-2)
+     (test/approx (flfirst-bessel (flonum 100) 100) +9.636667330e-2)
+
+
+     (test (flsecond-bessel zero 0) neginf)
+     (test (flsecond-bessel zero 1) neginf)
+     (test (flsecond-bessel zero 2) neginf)
+     (test (flsecond-bessel zero 3) neginf)
+     (test (flsecond-bessel zero 4) neginf)
+     (test (flsecond-bessel zero 5) neginf)
+     (test (flsecond-bessel zero 6) neginf)
+     (test (flsecond-bessel zero 7) neginf)
+     (test (flsecond-bessel zero 8) neginf)
+     (test (flsecond-bessel zero 9) neginf)
+     (test (flsecond-bessel zero 10) neginf)
+     (test (flsecond-bessel zero 20) neginf)
+
+     (test/approx (flsecond-bessel (flonum 0.4) 0)
+                  (flonum -0.6060245684))
+     (test/approx (flsecond-bessel (flonum 0.4) 1)
+                  (flonum -1.7808720443))
+     (test/approx (flsecond-bessel (flonum 0.4) 2)
+                  (flonum -8.29833565))
+     (test/approx (flsecond-bessel (flonum 0.4) 3)
+                  (flonum -8.1202e1))
+     (test/approx (flsecond-bessel (flonum 0.4) 4)
+                  (flonum -1.2097e3))
+     (test/approx (flsecond-bessel (flonum 0.4) 5)
+                  (flonum -2.4114e4))
+     (test/approx (flsecond-bessel (flonum 0.4) 6)
+                  (flonum -6.0163e5))
+     (test/approx (flsecond-bessel (flonum 0.4) 7)
+                  (flonum -1.8025e7))
+     (test/approx (flsecond-bessel (flonum 0.4) 8)
+                  (flonum -6.3027e8))
+     (test/approx (flsecond-bessel (flonum 0.4) 9)
+                  (flonum -2.5193e10))
+
+     (test/approx (flsecond-bessel one 0)
+                  (flonum +0.0882569642))
+     (test/approx (flsecond-bessel one 1)
+                  (flonum -0.7812128213))
+     (test/approx (flsecond-bessel one 2)
+                  (flonum -1.65068261))
+     (test/approx (flsecond-bessel one 3)
+                  (flonum -5.8215))
+     (test/approx (flsecond-bessel one 4)
+                  (flonum -3.3278e1))
+     (test/approx (flsecond-bessel one 5)
+                  (flonum -2.6041e2))
+     (test/approx (flsecond-bessel one 6)
+                  (flonum -2.5708e3))
+     (test/approx (flsecond-bessel one 7)
+                  (flonum -3.0589e4))
+     (test/approx (flsecond-bessel one 8)
+                  (flonum -4.2567e5))
+     (test/approx (flsecond-bessel one 9)
+                  (flonum -6.7802e6))
+
+     (test/approx (flsecond-bessel (flonum 17) 0)
+                  (flonum -0.0926371984))
+     (test/approx (flsecond-bessel (flonum 17) 1)
+                  (flonum +0.1672050361))
+     (test/approx (flsecond-bessel (flonum 17) 2)
+                  (flonum +0.11230838))
+     (test/approx (flsecond-bessel (flonum 17) 3)
+                  (flonum -0.14078))
+     (test/approx (flsecond-bessel (flonum 17) 4)
+                  (flonum -0.16200))
+     (test/approx (flsecond-bessel (flonum 17) 5)
+                  (flonum +0.06455))
+     (test/approx (flsecond-bessel (flonum 17) 6)
+                  (flonum +0.19996))
+     (test/approx (flsecond-bessel (flonum 17) 7)
+                  (flonum +0.07660))
+     (test/approx (flsecond-bessel (flonum 17) 8)
+                  (flonum -0.13688))
+     (test/approx (flsecond-bessel (flonum 17) 9)
+                  (flonum -0.20543))
+
+     (test/approx (flsecond-bessel (flonum 50) 0)
+                  (flonum -9.806499600e-2))
+     (test/approx (flsecond-bessel (flonum 50) 1)
+                  (flonum -5.679566800e-2))
+     (test/approx (flsecond-bessel (flonum 50) 2)
+                  (flonum +9.579316928e-2))
+     (test/approx (flsecond-bessel (flonum 50) 3)
+                  (flonum +6.445912154e-2))
+     (test/approx (flsecond-bessel (flonum 50) 4)
+                  (flonum -8.805807469e-2))
+     (test/approx (flsecond-bessel (flonum 50) 5)
+                  (flonum -7.854841349e-2))
+     (test/approx (flsecond-bessel (flonum 50) 6)
+                  (flonum +7.234839200e-2))
+     (test/approx (flsecond-bessel (flonum 50) 7)
+                  (flonum +9.591202757e-2))
+     (test/approx (flsecond-bessel (flonum 50) 8)
+                  (flonum -4.549302428e-2))
+     (test/approx (flsecond-bessel (flonum 50) 9)
+                  (flonum -1.104697953e-1))
+
+     (let ((f (lambda (n x y)
+                (test/approx (fl/ (flsecond-bessel x n) y)
+                             (flexpt x (flonum (- n)))))))
+       (f 10 (flonum 8) -0.97356279e9)
+       (f 20 (flonum 8) -0.962608e23)
+       )
+
+     (test/approx (flsecond-bessel (flonum 10) 10)   -3.598141522e-1)
+     (test/approx (flsecond-bessel (flonum 10) 15)   -6.364745877e0)
+     (test/approx (flsecond-bessel (flonum 10) 20)   -1.597483848e3)
+     (test/approx (flsecond-bessel (flonum 10) 50)   -3.641066502e27)
+     (test/approx (flsecond-bessel (flonum 10) 100)  -4.849148271e85)
+
+     (test/approx (flsecond-bessel (flonum 100) 10)  +5.833157440e-2)
+     (test/approx (flsecond-bessel (flonum 100) 15)  +7.879068618e-2)
+     (test/approx (flsecond-bessel (flonum 100) 20)  +5.124797200e-2)
+     (test/approx (flsecond-bessel (flonum 100) 50)  +7.650526379e-2)
+     (test/approx (flsecond-bessel (flonum 100) 100) -1.669214112e-1)
+
+
+     (test (flerf zero) zero)
+     (test (flerf posinf) one)
+     (test (flerf neginf) (fl- one))
+
+     (test/approx (flerf (flonum -0.5)) -0.5204998778)
+     (test/approx (flerf (flonum -1.0)) -0.8427007929)
+     (test/approx (flerf (flonum -1.5)) -0.9661051465)
+     (test/approx (flerf (flonum -2.0)) -0.9953222650)
+
+     (test/approx (flerf (flonum 0.25))  0.2763263902)
+     (test/approx (flerf (flonum 0.50))  0.5204998778)
+     (test/approx (flerf (flonum 0.75))  0.7111556337)
+     (test/approx (flerf (flonum 1.00))  0.8427007929)
+     (test/approx (flerf (flonum 1.25))  0.9229001283)
+     (test/approx (flerf (flonum 1.50))  0.9661051465)
+     (test/approx (flerf (flonum 1.75))  0.9866716712)
+     (test/approx (flerf (flonum 2.00))  0.9953222650)
+
+     (test (flerfc zero) one)
+     (test (flerfc posinf) zero)
+     (test (flerfc neginf) two)
+
+     (test/approx (flerfc (flonum -0.5)) 1.5204998778)
+     (test/approx (flerfc (flonum -1.0)) 1.8427007929)
+     (test/approx (flerfc (flonum -1.5)) 1.9661051465)
+     (test/approx (flerfc (flonum -2.0)) 1.9953222650)
+
+     (test/approx (flerfc (flonum 0.25)) (- 1.0 0.2763263902))
+     (test/approx (flerfc (flonum 0.50)) (- 1.0 0.5204998778))
+     (test/approx (flerfc (flonum 0.75)) (- 1.0 0.7111556337))
+     (test/approx (flerfc (flonum 1.00)) (- 1.0 0.8427007929))
+     (test/approx (flerfc (flonum 1.25)) (- 1.0 0.9229001283))
+     (test/approx (flerfc (flonum 1.50)) (- 1.0 0.9661051465))
+     (test/approx (flerfc (flonum 1.75)) (- 1.0 0.9866716712))
+     (test/approx (flerfc (flonum 2.00)) (- 1.0 0.9953222650))
+
+     (let* ((f (lambda (x y)
+                 (test/approx (fl* x (flexp (flsquare x)) (flerfc x))
+                              y)))
+            (g (lambda (x^-2 y)
+                 (f (flsqrt (fl/ x^-2)) y))))
+       (g (flonum 0.250) 0.5107914)
+       (g (flonum 0.125) 0.5340672)
+       (g (flonum 0.100) 0.5394141)
+       (g (flonum 0.075) 0.5450551)
+       (g (flonum 0.050) 0.5510295)
+       (g (flonum 0.025) 0.5573865)
+       (g (flonum 0.020) 0.5587090)
+       (g (flonum 0.015) 0.5600500)
+       (g (flonum 0.010) 0.5614099)
+       (g (flonum 0.005) 0.5627896))
+
+     )))

--- a/tests/scheme/run/flonum.sps
+++ b/tests/scheme/run/flonum.sps
@@ -1,0 +1,8 @@
+(import (scheme base)
+        (scheme write)
+        (tests scheme flonum)
+        (tests scheme test))
+
+(display "Running tests for (scheme flonum)\n")
+(run-flonum-tests)
+(report-test-results)

--- a/tests/scheme/test.sld
+++ b/tests/scheme/test.sld
@@ -1,0 +1,335 @@
+(define-library (tests scheme test)
+  (export test
+          test/approx
+          test/alts
+          test/exn
+          test/values
+          test/output
+          test/unspec
+          test/unspec-or-exn
+          test/unspec-flonum-or-exn
+          test/output/unspec
+          run-test
+          report-test-results
+
+          ;; FIXME: this is a hack
+
+          &assertion
+          &implementation-restriction
+          &who
+          &message
+          &irritants
+          &error
+          &syntax
+          &violation
+          &non-continuable
+
+          condition-message
+          condition-who
+          condition-irritants
+          who-condition?
+          error?
+          )
+
+  (import (scheme base)
+          (scheme cxr)
+          (scheme write))
+
+  (cond-expand
+   ((library (scheme inexact))
+    (import (scheme inexact)))
+   ((not (library (scheme inexact)))
+    (begin (define (infinite? x) (= x (/ x 2.0)))
+           (define (nan? x) (not (= x x))))))
+
+  (cond-expand
+   ((library (scheme complex))
+    (import (scheme complex)))
+   ((not (library (scheme complex)))
+    (begin (define (magnitude x) (abs x))
+           (define (real-part x) x)
+           (define (imag-part x) 0))))
+
+  (cond-expand
+   ((library (scheme file))
+    (import (scheme file)))
+   ((not (library (scheme file)))
+    (begin (define (delete-file fname) #t)
+           (define (file-exists? fname) #t)
+           (define (call-with-input-file fname proc)
+             (proc (current-input-port)))
+           (define (with-output-to-file fname thunk) (thunk)))))
+
+  (begin
+
+   ;; Fake condition system; see test/exn and test/unspec-or-exn.
+
+   (define &assertion '&assertion)
+   (define &implementation-restriction '&implementation-restriction)
+   (define &who '&who)
+   (define &message '&message)
+   (define &irritants '&irritants)
+   (define &error '&error)
+   (define &syntax '&syntax)
+   (define &violation '&violation)
+   (define &non-continuable '&non-continuable)
+
+   (define condition-message   error-object-message)
+   (define condition-who       error-object-message)
+   (define condition-irritants error-object-irritants)
+   (define who-condition?      error-object?)
+   (define error?              error-object?)
+
+   )
+
+  (begin
+
+   ;; Good enough for this file.
+
+   (define (for-all f xs . others)
+     (cond ((null? xs)
+            #t)
+           ((apply f (car xs) (map car others))
+            (apply for-all f (cdr xs) (map cdr others)))
+           (else
+            #f)))
+
+   (define (exists f xs . others)
+     (cond ((null? xs)
+            #f)
+           ((apply f (car xs) (map car others))
+            #t)
+           (else
+            (apply exists f (cdr xs) (map cdr others)))))
+
+   (define (get-string-n p n)
+     (let loop ((chars '())
+                (i 0))
+       (if (= i n)
+           (list->string (reverse chars))
+           (let ((c (read-char p)))
+             (if (char? c)
+                 (loop (cons c chars)
+                       (+ i 1))
+                 (loop chars n))))))
+
+   (define-record-type multiple-results
+     (make-multiple-results values)
+     multiple-results?
+     (values multiple-results-values))
+
+   (define-record-type approx
+     (make-approx value)
+     approx?
+     (value approx-value))
+
+   (define-record-type alts (make-alts values) alts?
+     (values alts-values))
+
+   (define-syntax test
+     (syntax-rules ()
+       ((_ expr expected)
+        (begin
+         ;; (write 'expr) (newline)
+         (run-test 'expr
+                   (catch-exns (lambda () expr))
+                   expected)))))
+
+   (define (catch-exns thunk)
+     (guard (c (#t &error))
+      (call-with-values thunk
+       (lambda x
+         (if (= 1 (length x))
+             (car x)
+             (make-multiple-results x))))))
+
+   (define-syntax test/approx
+     (syntax-rules ()
+      ((_ expr expected)
+       (run-test 'expr
+                 (make-approx expr)
+                 (make-approx expected)))))
+
+   (define-syntax test/alts
+     (syntax-rules ()
+      ((_ expr expected0 expected ...)
+       (run-test 'expr
+                 expr
+                 (make-alts (list expected0 expected ...))))))
+
+   (define (good-enough? x y)
+     ;; relative error should be with 0.1%, but greater
+     ;; relative error is allowed when the expected value
+     ;; is near zero.
+     (cond ((not (number? x)) #f)
+           ((not (number? y)) #f)
+           ((or (not (real? x))
+                (not (real? y)))
+            (and (good-enough? (real-part x) (real-part y))
+                 (good-enough? (imag-part x) (imag-part y))))
+           ((infinite? x)
+            (= x (* 2.0 y)))
+           ((infinite? y)
+            (= (* 2.0 x) y))
+           ((nan? y)
+            (nan? x))
+           ((> (magnitude y) 1e-6)
+            (< (/ (magnitude (- x y))
+                  (magnitude y))
+               1e-3))
+           (else
+            (< (magnitude (- x y)) 1e-6))))
+
+   ;; FIXME
+
+   (define-syntax test/exn
+     (syntax-rules ()
+      ((_ expr condition)
+       (test (guard (c (#t
+                        condition))
+                    expr)
+             condition))))
+
+   (define-syntax test/values
+     (syntax-rules ()
+      ((_ expr val ...)
+       (run-test 'expr
+                 (catch-exns (lambda () expr))
+                 (make-multiple-results (list val ...))))))
+
+   (define-syntax test/output
+     (syntax-rules ()
+      ((_ expr expected str)
+       (run-test 'expr
+                 (capture-output
+                  (lambda ()
+                    (run-test 'expr
+                              (guard (c (#t &error))
+                                     expr)
+                              expected)))
+                 str))))
+
+   (define-syntax test/unspec
+     (syntax-rules ()
+      ((_ expr)
+       (test (begin expr 'unspec) 'unspec))))
+
+   ;; FIXME
+
+   (define-syntax test/unspec-or-exn
+     (syntax-rules ()
+      ((_ expr condition)
+       (test (guard (c (#t
+                        'unspec))
+                    (begin expr 'unspec))
+             'unspec))))
+
+   ;; FIXME
+
+   (define-syntax test/unspec-flonum-or-exn
+     (syntax-rules ()
+      ((_ expr condition)
+       (test (guard (c (#t
+                        'unspec-or-flonum))
+                     (let ((v expr))
+                       (if (and (number? v)
+                                (inexact? v)
+                                (real? v))
+                           'unspec-or-flonum
+                           (if (eq? v 'unspec-or-flonum)
+                               (list v)
+                               v))))
+             'unspec-or-flonum))))
+
+   (define-syntax test/output/unspec
+     (syntax-rules ()
+      ((_ expr str)
+       (test/output (begin expr 'unspec) 'unspec str))))
+
+   (define checked 0)
+   (define failures '())
+
+   (define (capture-output thunk)
+     (if (file-exists? "tmp-catch-out")
+         (delete-file "tmp-catch-out"))
+     (dynamic-wind
+      (lambda () 'nothing)
+      (lambda ()
+        (with-output-to-file "tmp-catch-out"
+         thunk)
+        (call-with-input-file "tmp-catch-out"
+         (lambda (p)
+           (get-string-n p 1024))))
+      (lambda ()
+        (if (file-exists? "tmp-catch-out")
+            (delete-file "tmp-catch-out")))))
+  
+   (define (same-result? got expected)
+     (cond
+      ((and (real? expected) (nan? expected))
+       (and (real? got) (nan? got)))
+      ((approx? expected)
+       (and (approx? got)
+            (good-enough? (approx-value expected)
+                          (approx-value got))))
+      ((multiple-results? expected)
+       (and (multiple-results? got)
+            (= (length (multiple-results-values expected))
+               (length (multiple-results-values got)))
+            (for-all same-result?
+                     (multiple-results-values expected)
+                     (multiple-results-values got))))
+      ((alts? expected)
+       (exists (lambda (e) (same-result? got e))
+               (alts-values expected)))
+      (else (equal? got expected))))
+    
+   (define (run-test expr got expected)
+     (set! checked (+ 1 checked))
+     (unless (same-result? got expected)
+      (set! failures
+            (cons (list expr got expected)
+                  failures))))
+
+   (define (write-result prefix v)
+     (cond
+      ((multiple-results? v)
+       (for-each (lambda (v)
+                   (write-result prefix v))
+                 (multiple-results-values v)))
+      ((approx? v)
+       (display prefix)
+       (display "approximately ")
+       (write (approx-value v)))
+      ((alts? v)
+       (write-result (string-append prefix "   ")
+                     (car (alts-values v)))
+       (for-each (lambda (v)
+                   (write-result (string-append prefix "OR ")
+                                 v))
+                 (cdr (alts-values v))))
+      (else
+       (display prefix)
+       (write v))))
+
+   (define (report-test-results)
+     (if (null? failures)
+         (begin
+          (display checked)
+          (display " tests passed\n"))
+         (begin
+          (display (length failures))
+          (display " tests failed:\n\n")
+          (for-each (lambda (t)
+                      (display "Expression:\n ")
+                      (write (car t))
+                      (display "\nResult:")
+                      (write-result "\n " (cadr t))
+                      (display "\nExpected:")
+                      (write-result "\n " (caddr t))
+                      (display "\n\n"))
+                    (reverse failures))
+           (display (length failures))
+           (display " of ")
+           (display checked)
+           (display " tests failed.\n"))))))

--- a/tests/srfi-144-test.scm
+++ b/tests/srfi-144-test.scm
@@ -1,0 +1,624 @@
+;;; Copyright (C) William D Clinger (2016).
+;;; 
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use,
+;;; copy, modify, merge, publish, distribute, sublicense, and/or
+;;; sell copies of the Software, and to permit persons to whom the
+;;; Software is furnished to do so, subject to the following
+;;; conditions:
+;;; 
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;; 
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+;;; OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;;; OTHER DEALINGS IN THE SOFTWARE. 
+
+;;; This is a Larceny-specific program that tests the accuracy and
+;;; speed of SRFI 144 procedures, producing gnuplot-compatible
+;;; data files that can be used to graph the accuracy of selected
+;;; procedures.
+;;;
+;;; This program uses Larceny's FFI to access C library routines.
+;;; Larceny's FFI is not implemented on all platforms, so
+;;; platform-independent scripts should not run this test program.
+;;;
+;;; It should be possible to modify the FFI-dependent part of this
+;;; test program so it will run on other systems that provide an FFI
+;;; to C libraries.
+
+(import (scheme base)
+        (scheme inexact)
+        (srfi 144)
+        (scheme file)
+        (scheme write)
+        (scheme time)
+        (rename (primitives r5rs:require)
+                (r5rs:require require))
+        (primitives foreign-procedure))
+
+(define output-directory "/tmp")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; FFI-dependent definitions
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(require 'std-ffi)
+
+(define nextafter (foreign-procedure "nextafter" '(double double) 'double))
+(define copysign  (foreign-procedure "copysign"  '(double double) 'double))
+(define ldexp     (foreign-procedure "ldexp"     '(double int)    'double))
+(define modf      (foreign-procedure "modf"      '(double int)    'double))
+(define logb      (foreign-procedure "logb"      '(double)        'double))
+(define ilogb     (foreign-procedure "ilogb"     '(double)        'int))
+(define frexp     (foreign-procedure "frexp"     '(double boxed)  'double))
+;(define signbit     'MACRO)
+
+;(define isfinite    'MACRO)
+;(define isinf       'MACRO)
+;(define isnan       'MACRO)
+;(define isnormal    'MACRO)    ; fpclassify is also a macro
+;(define issubnormal 'MACRO)    ; fpclassify is also a macro
+
+(define fma      (foreign-procedure "fma" '(double double double) 'double))
+(define fabs      (foreign-procedure "fabs"      '(double)        'double))
+(define fdim      (foreign-procedure "fdim"      '(double double) 'double))
+(define c:floor   (foreign-procedure "floor"     '(double)        'double))
+(define ceil      (foreign-procedure "ceil"      '(double)        'double))
+(define c:round   (foreign-procedure "round"     '(double)        'double))
+(define trunc     (foreign-procedure "trunc"     '(double)        'double))
+
+(define c:exp     (foreign-procedure "exp"       '(double)        'double))
+(define exp2      (foreign-procedure "exp2"      '(double)        'double))
+(define expm1     (foreign-procedure "expm1"     '(double)        'double))
+(define c:sqrt    (foreign-procedure "sqrt"      '(double)        'double))
+(define cbrt      (foreign-procedure "cbrt"      '(double)        'double))
+(define hypot     (foreign-procedure "hypot"     '(double double) 'double))
+(define pow       (foreign-procedure "pow"       '(double double) 'double))
+(define c:log     (foreign-procedure "log"       '(double)        'double))
+(define log1p     (foreign-procedure "log1p"     '(double)        'double))
+(define log2      (foreign-procedure "log2"      '(double)        'double))
+(define log10     (foreign-procedure "log10"     '(double)        'double))
+
+(define c:sin     (foreign-procedure "sin"       '(double)        'double))
+(define c:cos     (foreign-procedure "cos"       '(double)        'double))
+(define c:tan     (foreign-procedure "tan"       '(double)        'double))
+(define c:asin    (foreign-procedure "asin"      '(double)        'double))
+(define c:acos    (foreign-procedure "acos"      '(double)        'double))
+(define c:atan    (foreign-procedure "atan"      '(double)        'double))
+(define atan2     (foreign-procedure "atan2"     '(double double) 'double))
+
+(define sinh      (foreign-procedure "sinh"      '(double)        'double))
+(define cosh      (foreign-procedure "cosh"      '(double)        'double))
+(define tanh      (foreign-procedure "tanh"      '(double)        'double))
+(define asinh     (foreign-procedure "asinh"     '(double)        'double))
+(define acosh     (foreign-procedure "acosh"     '(double)        'double))
+(define atanh     (foreign-procedure "atanh"     '(double)        'double))
+
+(define tgamma    (foreign-procedure "tgamma"    '(double)        'double))
+(define lgamma    (foreign-procedure "lgamma"    '(double)        'double))
+(define jn        (foreign-procedure "jn"        '(int double)    'double))
+(define yn        (foreign-procedure "yn"        '(int double)    'double))
+(define erf       (foreign-procedure "erf"       '(double)        'double))
+(define erfc      (foreign-procedure "erfc"      '(double)        'double))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; End of FFI-dependent definitions
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Generators of test inputs.
+;;; Each generator should produce about 1024 test inputs.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (zero-to-one)
+  (let ((i 0))
+    (lambda ()
+      (if (> i 1024)
+          #f
+          (let ((result (/ i 1024.0)))
+            (set! i (+ i 1))
+            result)))))
+
+(define (negative-one-to-one)
+  (let ((i 0))
+    (lambda ()
+      (if (> i 1024)
+          #f
+          (let ((result (/ (- i 512) 512.0)))
+            (set! i (+ i 1))
+            result)))))
+
+(define (negative-eight-to-eight)
+  (let ((next (negative-one-to-one)))
+    (lambda ()
+      (let ((result (next)))
+        (if result (* 8.0 result) result)))))
+
+(define (negative-2pi-to-2pi)
+  (let ((i 0))
+    (lambda ()
+      (if (> i 1024)
+          #f
+          (let ((result (fl/ (fl* fl-2pi (- i 512.0)) 512.0)))
+            (set! i (+ i 1))
+            result)))))
+
+(define (zero-to-infinity)
+  (let ((i 0))
+    (lambda ()
+      (if (> i 1025)
+          #f
+          (let ((result (flonum (expt 2.0 (- (+ i i) 1025)))))
+            (set! i (+ i 1))
+            result)))))
+
+(define (negative-infinity-to-infinity)
+  (let ((i 0))
+    (lambda ()
+      (if (> i 1024)
+          #f
+          (cond ((< i 512)
+                 (let ((result (fl- (flonum (expt 2.0 (- 1024 i i i i))))))
+                   (set! i (+ i 1))
+                   result))
+                ((= i 512)
+                 (set! i (+ i 1))
+                 0.0)
+                (else
+                 (let ((result (flonum (expt 2.0 (+ i i i i -3072)))))
+                   (set! i (+ i 1))
+                   result)))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Accuracy
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Given the name of a function, two unary functions, a generator
+;;; of test inputs, and (optionally) an output port, where the
+;;; first unary function is assumed to be perfectly accurate,
+;;; writes RMS error (over a small window) to the output port.
+
+(define (write-absolute-error name f0 f1 next . rest)
+  (let ((p (if (null? rest) (current-output-port) (car rest))))
+    (define (loop x-3 x-2 x-1 x x+1 x+2 x+3
+                  e-3 e-2 e-1 e e+1 e+2 e+3)
+      (let ((rms (flsqrt (fl/ (fl+ e-3 e-2 e-1 e e+1 e+2 e+3) 7.0))))
+        (write x p)
+        (display "    " p)
+        (write rms p)
+        (if (not (flfinite? rms))
+            (begin (display "    # " p)
+                   (write (map f1 (list x-3 x-2 x-1 x x+1 x+2 x+3)) p)))
+        (newline p)
+        (let ((x+4 (next)))
+          (if x+4
+              (loop x-2 x-1 x x+1 x+2 x+3 x+4
+                    e-2 e-1 e e+1 e+2 e+3 (square-error x+4))
+              (display "\n\n" p)))))
+    (define (square-error x)
+      (let ((y0 (f0 x))
+            (y1 (f1 x)))
+        (cond ((fl=? y0 y1)
+               0.0)
+              ((or (flinfinite? y0) (flinfinite? y1))
+               +inf.0)
+              ((and (flnan? y0) (flnan? y1))
+               0.0)
+              (else
+               (flsquare (fl- y1 y0))))))
+    (display "# " p)
+    (display name p)
+    (newline p)
+    (let* ((x-3 (next))
+           (x-2 (next))
+           (x-1 (next))
+           (x   (next))
+           (x+1 (next))
+           (x+2 (next))
+           (x+3 (next)))
+      (if x+3
+          (loop x-3 x-2 x-1 x x+1 x+2 x+3
+                (square-error x-3)
+                (square-error x-2)
+                (square-error x-1)
+                (square-error x)
+                (square-error x+1)
+                (square-error x+2)
+                (square-error x+3))))))
+
+(define (write-absolute-error-to-file name f0 f1 next filename)
+  (let ((filename (string-append output-directory "/" filename)))
+    (delete-file filename)
+    (call-with-output-file
+     filename
+     (lambda (p)
+       (write-absolute-error name f0 f1 next p)))))
+
+(define (write-relative-error name f0 f1 next . rest)
+  (let ((p (if (null? rest) (current-output-port) (car rest))))
+    (define (loop x-3 x-2 x-1 x x+1 x+2 x+3
+                  e-3 e-2 e-1 e e+1 e+2 e+3)
+      (let ((rms (flsqrt (fl/ (fl+ e-3 e-2 e-1 e e+1 e+2 e+3) 7.0))))
+        (write x p)
+        (display "    " p)
+        (write rms p)
+        (if (not (flfinite? rms))
+            (begin (display "    # " p)
+                   (write (map f1 (list x-3 x-2 x-1 x x+1 x+2 x+3)) p)))
+        (newline p)
+        (let ((x+4 (next)))
+          (if x+4
+              (loop x-2 x-1 x x+1 x+2 x+3 x+4
+                    e-2 e-1 e e+1 e+2 e+3 (square-error x+4))
+              (display "\n\n" p)))))
+    (define (square-error x)
+      (let retry ((y0 (f0 x))
+                  (y1 (f1 x)))
+        (cond ((fl=? y0 y1)
+               0.0)
+              ((and (flnan? y0) (flnan? y1))
+               0.0)
+              ((or (flnan? y0) (flnan? y1))
+               +inf.0)
+              ((flinfinite? y0)
+               (retry fl-greatest y1))
+              ((flinfinite? y1)
+               (retry y0 fl-greatest))
+              ((fl<? -1.0 (flabs y0) 1.0) ; if y0 < 1, report absolute error
+               (flsquare (fl- y1 y0)))
+              (else
+               (flsquare (fl/ (fl- y1 y0) y0))))))
+    (display "# " p)
+    (display name p)
+    (display " (relative error)" p)
+    (newline p)
+    (let* ((x-3 (next))
+           (x-2 (next))
+           (x-1 (next))
+           (x   (next))
+           (x+1 (next))
+           (x+2 (next))
+           (x+3 (next)))
+      (if x+3
+          (loop x-3 x-2 x-1 x x+1 x+2 x+3
+                (square-error x-3)
+                (square-error x-2)
+                (square-error x-1)
+                (square-error x)
+                (square-error x+1)
+                (square-error x+2)
+                (square-error x+3))))))
+
+(define (write-relative-error-to-file name f0 f1 next filename)
+  (let ((filename (string-append output-directory "/" filename)))
+    (delete-file filename)
+    (call-with-output-file
+     filename
+     (lambda (p)
+       (write-relative-error name f0 f1 next p)))))
+
+
+(write-relative-error-to-file "log" c:log fllog (zero-to-infinity)
+                              "log.data")
+(write-relative-error-to-file "sin" c:sin flsin (negative-2pi-to-2pi)
+                              "sin.data")
+(write-relative-error-to-file "Gamma" tgamma flgamma
+                              (negative-infinity-to-infinity)
+                              "gamma.data")
+(write-relative-error-to-file "Gamma" tgamma flgamma (negative-eight-to-eight)
+                              "gamma-small.data")
+(write-relative-error-to-file "J_0"
+                      (lambda (x) (jn 0 x))
+                      (lambda (x) (flfirst-bessel x 0))
+                      (negative-infinity-to-infinity)
+                      "j0.data")
+(write-relative-error-to-file "J_0"
+                      (lambda (x) (jn 0 x))
+                      (lambda (x) (flfirst-bessel x 0))
+                      (negative-eight-to-eight)
+                      "j0-small.data")
+(write-relative-error-to-file "Y_0"
+                      (lambda (x) (yn 0 x))
+                      (lambda (x) (flsecond-bessel x 0))
+                      (negative-infinity-to-infinity)
+                      "y0.data")
+(write-relative-error-to-file "Y_0"
+                      (lambda (x) (yn 0 x))
+                      (lambda (x) (flsecond-bessel x 0))
+                      (negative-eight-to-eight)
+                      "y0-small.data")
+(write-relative-error-to-file "J_1"
+                      (lambda (x) (jn 1 x))
+                      (lambda (x) (flfirst-bessel x 1))
+                      (negative-infinity-to-infinity)
+                      "j1.data")
+(write-relative-error-to-file "J_1"
+                      (lambda (x) (jn 1 x))
+                      (lambda (x) (flfirst-bessel x 1))
+                      (negative-eight-to-eight)
+                      "j1-small.data")
+(write-relative-error-to-file "Y_1"
+                      (lambda (x) (yn 1 x))
+                      (lambda (x) (flsecond-bessel x 1))
+                      (negative-infinity-to-infinity)
+                      "y1.data")
+(write-relative-error-to-file "Y_1"
+                      (lambda (x) (yn 1 x))
+                      (lambda (x) (flsecond-bessel x 1))
+                      (negative-eight-to-eight)
+                      "y1-small.data")
+(write-relative-error-to-file "J_2"
+                      (lambda (x) (jn 2 x))
+                      (lambda (x) (flfirst-bessel x 2))
+                      (negative-infinity-to-infinity)
+                      "j2.data")
+(write-relative-error-to-file "J_2"
+                      (lambda (x) (jn 2 x))
+                      (lambda (x) (flfirst-bessel x 2))
+                      (negative-eight-to-eight)
+                      "j2-small.data")
+(write-relative-error-to-file "Y_2"
+                      (lambda (x) (yn 2 x))
+                      (lambda (x) (flsecond-bessel x 2))
+                      (negative-infinity-to-infinity)
+                      "y2.data")
+(write-relative-error-to-file "Y_2"
+                      (lambda (x) (yn 2 x))
+                      (lambda (x) (flsecond-bessel x 2))
+                      (negative-eight-to-eight)
+                      "y2-small.data")
+(write-relative-error-to-file "J_3"
+                      (lambda (x) (jn 3 x))
+                      (lambda (x) (flfirst-bessel x 3))
+                      (negative-infinity-to-infinity)
+                      "j3.data")
+(write-relative-error-to-file "J_3"
+                      (lambda (x) (jn 3 x))
+                      (lambda (x) (flfirst-bessel x 3))
+                      (negative-eight-to-eight)
+                      "j3-small.data")
+(write-relative-error-to-file "Y_3"
+                      (lambda (x) (yn 3 x))
+                      (lambda (x) (flsecond-bessel x 3))
+                      (negative-infinity-to-infinity)
+                      "y3.data")
+(write-relative-error-to-file "Y_3"
+                      (lambda (x) (yn 3 x))
+                      (lambda (x) (flsecond-bessel x 3))
+                      (negative-eight-to-eight)
+                      "y3-small.data")
+(write-relative-error-to-file "J_4"
+                      (lambda (x) (jn 4 x))
+                      (lambda (x) (flfirst-bessel x 4))
+                      (negative-infinity-to-infinity)
+                      "j4.data")
+(write-relative-error-to-file "J_4"
+                      (lambda (x) (jn 4 x))
+                      (lambda (x) (flfirst-bessel x 4))
+                      (negative-eight-to-eight)
+                      "j4-small.data")
+(write-relative-error-to-file "Y_4"
+                      (lambda (x) (yn 4 x))
+                      (lambda (x) (flsecond-bessel x 4))
+                      (negative-infinity-to-infinity)
+                      "y4.data")
+(write-relative-error-to-file "Y_4"
+                      (lambda (x) (yn 4 x))
+                      (lambda (x) (flsecond-bessel x 4))
+                      (negative-eight-to-eight)
+                      "y4-small.data")
+(write-relative-error-to-file "J_100"
+                      (lambda (x) (jn 100 x))
+                      (lambda (x) (flfirst-bessel x 100))
+                      (negative-infinity-to-infinity)
+                      "j100.data")
+(write-relative-error-to-file "J_100"
+                      (lambda (x) (jn 100 x))
+                      (lambda (x) (flfirst-bessel x 100))
+                      (negative-eight-to-eight)
+                      "j100-small.data")
+(write-relative-error-to-file "Y_100"
+                      (lambda (x) (yn 100 x))
+                      (lambda (x) (flsecond-bessel x 100))
+                      (negative-infinity-to-infinity)
+                      "y100.data")
+(write-relative-error-to-file "Y_100"
+                      (lambda (x) (yn 100 x))
+                      (lambda (x) (flsecond-bessel x 100))
+                      (negative-eight-to-eight)
+                      "y100-small.data")
+(write-relative-error-to-file "erf" erf flerf (negative-infinity-to-infinity)
+                              "erf.data")
+(write-relative-error-to-file "erf" erf flerf (negative-eight-to-eight)
+                              "erf-small.data")
+(write-relative-error-to-file "erfc" erfc flerfc (negative-infinity-to-infinity)
+                              "erfc.data")
+(write-relative-error-to-file "erfc" erfc flerfc (negative-eight-to-eight)
+                              "erfc-small.data")
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Benchmarking portable definitions against the C definitions.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-syntax cmp
+  (syntax-rules ()
+   ((cmp f1 f2 g)
+    (compare 'f1 'f2 f1 f2 g))))
+
+;;; Given the names of two functions, the two unary functions themselves,
+;;; and a thunk that returns a generator of test inputs, compares the
+;;; speed of the functions and writes a summary to the current output port.
+
+(define (compare name1 name2 f1 f2 thunk)
+  (define xs0
+    (let loop ((xs '())
+               (g (thunk)))
+      (let ((x (g)))
+        (if x
+            (loop (cons x xs) g)
+            (reverse xs)))))
+  (define test-time-in-jiffies
+    (max 20 (quotient (jiffies-per-second) 2)))
+  (define (iterations-per-test-time f)
+    (let ((completion-time (+ (current-jiffy) test-time-in-jiffies)))
+      (define (loop count xs)
+        (cond ((not (null? xs))
+               (f (car xs))
+               (loop count (cdr xs)))
+              ((< (current-jiffy) completion-time)
+               (loop (+ 1 count) xs0))
+              (else
+               count)))
+      (loop 0 xs0)))
+  (define (round1/ p q)
+    (/ (round (/ (* 10.0 p) (max 1.0 q))) 10.0))
+  (display "Comparing ")
+  (write name1)
+  (display " and ")
+  (write name2)
+  (newline)
+  (let* ((count1 (iterations-per-test-time f1))
+         (count2 (iterations-per-test-time f2)))
+;   (write (list count1 count2)) (newline)
+    (display "        ")
+    (write (max (round1/ count2 count1) (round1/ count1 count2)))
+    (display " times as ")
+    (display (if (< count1 count2)
+                 "slow ********************************"
+                 "fast"))
+    (newline) (newline)))
+
+(cmp (lambda (x) (fladjacent x 1.0))
+     (lambda (x) (nextafter x 1.0))
+     negative-infinity-to-infinity)
+
+(cmp (lambda (x) (flcopysign x 5.6))
+     (lambda (x) (copysign 3.4 5.6))
+     negative-infinity-to-infinity)
+
+(cmp (lambda (x) (make-flonum x 5))
+     (lambda (x) (ldexp x 5))
+     negative-infinity-to-infinity)
+
+#;
+(let ((flinteger-fraction
+       (lambda (x)
+         (call-with-values (lambda () (flinteger-fraction x))
+                           (lambda (x y) x)))))
+  (cmp (flinteger-fraction 3.4) (modf 3.4 FIXME)))
+
+(cmp flexponent logb zero-to-infinity)
+
+;(cmp (flinteger-exponent 3.4) (ilogb 3.4))
+#;
+(let ((flnormalized-fraction-exponent
+       (lambda (x)
+         (call-with-values (lambda () (flnormalized-fraction-exponent 3.4))
+                           (lambda (x y) x)))))
+  (cmp (flnormalized-fraction-exponent 3.4) (frexp 3.4 FIXME)))
+
+
+(cmp (lambda (x) (fl+* x x x))
+     (lambda (x) (fma x x x))
+     negative-eight-to-eight)
+(cmp (lambda (x) (fl+* x x x))
+     (lambda (x) (+ (* x x) x))
+     negative-eight-to-eight)
+(cmp flabs fabs negative-infinity-to-infinity)
+(cmp (lambda (x) (flposdiff x 5.6))
+     (lambda (x) (fdim x 5.6))
+     negative-infinity-to-infinity)
+(cmp flfloor c:floor negative-infinity-to-infinity)
+(cmp flceiling ceil negative-infinity-to-infinity)
+(cmp flround c:round negative-infinity-to-infinity)
+(cmp fltruncate trunc negative-infinity-to-infinity)
+
+(cmp flexp c:exp negative-infinity-to-infinity)
+(cmp flexp2 exp2 negative-infinity-to-infinity)
+(cmp flexp-1 expm1 negative-infinity-to-infinity)
+(cmp flsqrt c:sqrt zero-to-infinity)
+(cmp flcbrt cbrt negative-infinity-to-infinity)
+(cmp (lambda (x) (flhypot x x))
+     (lambda (x) (hypot x x))
+     negative-infinity-to-infinity)
+(cmp (lambda (x) (flexpt x x))
+     (lambda (x) (pow x x))
+     zero-to-infinity)
+(cmp fllog c:log zero-to-infinity)
+(cmp fllog1+ log1p zero-to-infinity)
+(cmp fllog2 log2 zero-to-infinity)
+(cmp fllog10 log10 zero-to-infinity)
+
+(cmp flsin c:sin negative-infinity-to-infinity)
+(cmp flcos c:cos negative-infinity-to-infinity)
+(cmp fltan c:tan negative-infinity-to-infinity)
+(cmp flasin c:asin negative-one-to-one)
+(cmp flacos c:acos negative-one-to-one)
+(cmp flatan c:atan negative-infinity-to-infinity)
+(cmp (lambda (y) (flatan y 5.6))
+     (lambda (y) (atan2 y 5.6))
+     negative-infinity-to-infinity)
+
+(cmp flsinh sinh negative-eight-to-eight)
+(cmp flcosh cosh negative-eight-to-eight)
+(cmp fltanh tanh negative-2pi-to-2pi)
+(cmp flasinh asinh zero-to-one)
+(cmp flacosh acosh zero-to-infinity)
+(cmp flatanh atanh negative-one-to-one)
+
+(cmp flgamma tgamma negative-infinity-to-infinity)
+(cmp flloggamma lgamma negative-infinity-to-infinity)
+
+(cmp (lambda (x) (flfirst-bessel x 0))
+     (lambda (x) (jn 0 x))
+     negative-infinity-to-infinity)
+(cmp (lambda (x) (flfirst-bessel x 1))
+     (lambda (x) (jn 1 x))
+     negative-infinity-to-infinity)
+(cmp (lambda (x) (flfirst-bessel x 2))
+     (lambda (x) (jn 2 x))
+     negative-infinity-to-infinity)
+(cmp (lambda (x) (flfirst-bessel x 5))
+     (lambda (x) (jn 5 x))
+     negative-infinity-to-infinity)
+(cmp (lambda (x) (flfirst-bessel x 100))
+     (lambda (x) (jn 100 x))
+     negative-infinity-to-infinity)
+
+(cmp (lambda (x) (flsecond-bessel x 0))
+     (lambda (x) (yn 0 x))
+     negative-infinity-to-infinity)
+(cmp (lambda (x) (flsecond-bessel x 1))
+     (lambda (x) (yn 1 x))
+     negative-infinity-to-infinity)
+(cmp (lambda (x) (flsecond-bessel x 2))
+     (lambda (x) (yn 2 x))
+     negative-infinity-to-infinity)
+(cmp (lambda (x) (flsecond-bessel x 5))
+     (lambda (x) (yn 5 x))
+     negative-infinity-to-infinity)
+(cmp (lambda (x) (flsecond-bessel x 100))
+     (lambda (x) (yn 100 x))
+     negative-infinity-to-infinity)
+
+(cmp flerf erf negative-eight-to-eight)
+(cmp flerfc erfc negative-eight-to-eight)


### PR DESCRIPTION
Should run in every complete implementation of R7RS (small).

Tested in Larceny v0.99 and Sagittarius 0.8.4.  A few tests may fail because of minor bugs, mostly related to infinities and NaNs.  The current development version of Larceny passes all tests.