### PR TITLE
Corrected sample implementation of flexponent and flinteger-exponent.

### DIFF
--- a/srfi/144.body.scm
+++ b/srfi/144.body.scm
@@ -162,11 +162,8 @@
          (result2 (fl- x result1)))
     (values result1 result2)))
 
-;;; The 8th draft of SRFI 144 will say flexponent returns the inexact
-;;; integer obtained by truncating toward zero.
-
 (define (flexponent x)
-  (fltruncate (fllog2 (flabs x))))
+  (floor (fllog2 (flabs x))))
 
 (define (flinteger-exponent x)
   (exact (flexponent x)))
@@ -193,6 +190,9 @@
          (values 0.5 (+ 3 (exact (round (fllog2 fl-greatest))))))
         ((flnormalized? x)
          (let* ((result2 (exact (flround (fllog2 x))))
+                (result2 (if (integer? result2)
+                             result2
+                             (round result2)))
                 (two^result2 (inexact (expt 2.0 result2))))
            (if (flinfinite? two^result2)
                (call-with-values
@@ -427,7 +427,7 @@
   (if (fl>? base 1.0)
       (flop1 'procedure-created-by-make-fllog-base
              (lambda (x) (log x base)))
-      (error "argument to make-fllog-base should be greater than 1.0" base)))
+      (error "argument to make-fllog-base must be greater than 1.0" base)))
 
 ;;; Trigonometric functions
 

--- a/tests/scheme/flonum.sld
+++ b/tests/scheme/flonum.sld
@@ -307,7 +307,7 @@
                      posinf))
      (test-assert (= (* 2 fl-greatest) posinf))
      (test-assert (= 1 (/ (+ 1 (+ 1.0 fl-epsilon)) 2)))
-     (test-assert (= 0 (/ fl-least 2)))
+     (test-assert (= 0.0 (/ fl-least 2)))
 
      (test-assert (boolean? fl-fast-fl+*))
      (test-assert (exact-integer? fl-integer-exponent-zero))
@@ -397,12 +397,12 @@
      (test/approx (flexponent (flexpt two (flonum +4.5)))
                   (flonum +4))
      (test/approx (flexponent (flexpt two (flonum -4.5)))
-                  (flonum -4))
+                  (flonum -5))
 
      (test (flinteger-exponent (flexpt two (flonum 12)))   12)
      (test (flinteger-exponent (flexpt two (flonum 12.5))) 12)
      (test (flinteger-exponent (flexpt two (flonum -5)))   -5)
-     (test (flinteger-exponent (flexpt two (flonum -4.5))) -4)
+     (test (flinteger-exponent (flexpt two (flonum -4.5))) -5)
 
      (let* ((correct?
              (lambda (x y n)
@@ -907,7 +907,7 @@
                  (let ((f (make-fllog-base base)))
                    (for-each (lambda (x)
                                (test/approx (flexpt (flonum base) (f x)) x))
-                             (filter positive? somereals))))
+                             (filter flpositive? somereals))))
                (map flonum '(3 7 19)))
 
      ;; Trigonometric functions


### PR DESCRIPTION
Corrects implementation of `flexponent` and `flinteger-exponent` by having them call `floor` instead of `truncate`. Corrects related tests and fixes minor portability problems with a couple of others.